### PR TITLE
Add firestore chat list

### DIFF
--- a/chatGPT/Data/ChatRepositoryImpl.swift
+++ b/chatGPT/Data/ChatRepositoryImpl.swift
@@ -1,0 +1,29 @@
+import Foundation
+import RxSwift
+
+final class ChatRepositoryImpl: ChatRepository {
+    private let dataSource: FirebaseChatDataSource
+
+    init(dataSource: FirebaseChatDataSource) {
+        self.dataSource = dataSource
+    }
+
+    func fetchChats() -> Observable<[Chat]> {
+        dataSource.fetchChats().map { $0.map { $0.toDomain() } }
+    }
+
+    func createChat(title: String) -> Observable<Chat> {
+        dataSource.createChat(title: title).map { $0.toDomain() }
+    }
+
+    func appendMessage(chatID: String, message: ChatRecordMessage) -> Observable<Void> {
+        let dto = ChatMessageDTO(id: message.id, text: message.text, isUser: message.isUser, createdAt: message.createdAt)
+        return dataSource.appendMessage(chatID: chatID, message: dto)
+    }
+}
+
+private extension ChatDTO {
+    func toDomain() -> Chat {
+        Chat(id: id, title: title, messages: [], createdAt: createdAt)
+    }
+}

--- a/chatGPT/Data/FirebaseChatDataSource.swift
+++ b/chatGPT/Data/FirebaseChatDataSource.swift
@@ -1,0 +1,85 @@
+import Foundation
+import FirebaseFirestore
+import FirebaseAuth
+import RxSwift
+
+struct ChatDTO: Codable {
+    let id: String
+    let title: String
+    let createdAt: Date
+}
+
+struct ChatMessageDTO: Codable {
+    let id: String
+    let text: String
+    let isUser: Bool
+    let createdAt: Date
+}
+
+final class FirebaseChatDataSource {
+    private let db = Firestore.firestore()
+
+    private var userID: String {
+        Auth.auth().currentUser?.uid ?? ""
+    }
+
+    func fetchChats() -> Observable<[ChatDTO]> {
+        Observable.create { observer in
+            self.db.collection("users").document(self.userID)
+                .collection("chats")
+                .order(by: "createdAt", descending: true)
+                .getDocuments { snapshot, error in
+                    if let error = error {
+                        observer.onError(error)
+                    } else {
+                        let chats = snapshot?.documents.compactMap { try? $0.data(as: ChatDTO.self) } ?? []
+                        observer.onNext(chats)
+                        observer.onCompleted()
+                    }
+                }
+            return Disposables.create()
+        }
+    }
+
+    func createChat(title: String) -> Observable<ChatDTO> {
+        Observable.create { observer in
+            let ref = self.db.collection("users").document(self.userID)
+                .collection("chats").document()
+            let dto = ChatDTO(id: ref.documentID, title: title, createdAt: Date())
+            do {
+                try ref.setData(from: dto) { error in
+                    if let error = error {
+                        observer.onError(error)
+                    } else {
+                        observer.onNext(dto)
+                        observer.onCompleted()
+                    }
+                }
+            } catch {
+                observer.onError(error)
+            }
+            return Disposables.create()
+        }
+    }
+
+    func appendMessage(chatID: String, message: ChatMessageDTO) -> Observable<Void> {
+        Observable.create { observer in
+            let ref = self.db.collection("users").document(self.userID)
+                .collection("chats").document(chatID)
+                .collection("messages").document(message.id)
+            do {
+                try ref.setData(from: message) { error in
+                    if let error = error {
+                        observer.onError(error)
+                    } else {
+                        observer.onNext(())
+                        observer.onCompleted()
+                    }
+                }
+            } catch {
+                observer.onError(error)
+            }
+            return Disposables.create()
+        }
+    }
+}

--- a/chatGPT/Domain/Entity/Chat.swift
+++ b/chatGPT/Domain/Entity/Chat.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+struct Chat {
+    let id: String
+    let title: String
+    var messages: [ChatRecordMessage]
+    let createdAt: Date
+}
+
+struct ChatRecordMessage {
+    let id: String
+    let text: String
+    let isUser: Bool
+    let createdAt: Date
+}

--- a/chatGPT/Domain/Repository/ChatRepository.swift
+++ b/chatGPT/Domain/Repository/ChatRepository.swift
@@ -1,0 +1,8 @@
+import Foundation
+import RxSwift
+
+protocol ChatRepository {
+    func fetchChats() -> Observable<[Chat]>
+    func createChat(title: String) -> Observable<Chat>
+    func appendMessage(chatID: String, message: ChatRecordMessage) -> Observable<Void>
+}

--- a/chatGPT/Domain/UseCase/ChatUseCase.swift
+++ b/chatGPT/Domain/UseCase/ChatUseCase.swift
@@ -1,0 +1,22 @@
+import Foundation
+import RxSwift
+
+final class ChatUseCase {
+    private let repository: ChatRepository
+
+    init(repository: ChatRepository) {
+        self.repository = repository
+    }
+
+    func fetchChats() -> Observable<[Chat]> {
+        repository.fetchChats()
+    }
+
+    func createChat(title: String) -> Observable<Chat> {
+        repository.createChat(title: title)
+    }
+
+    func appendMessage(chatID: String, message: ChatRecordMessage) -> Observable<Void> {
+        repository.appendMessage(chatID: chatID, message: message)
+    }
+}

--- a/chatGPT/Presentation/Scene/ChatList/ChatListViewController.swift
+++ b/chatGPT/Presentation/Scene/ChatList/ChatListViewController.swift
@@ -1,0 +1,51 @@
+import UIKit
+import SnapKit
+import RxSwift
+import RxCocoa
+
+final class ChatListViewController: UIViewController {
+    private let viewModel: ChatListViewModel
+    private let disposeBag = DisposeBag()
+    var onSelectChat: ((Chat) -> Void)?
+    private let tableView = UITableView()
+
+    init(viewModel: ChatListViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        layout()
+        bind()
+    }
+
+    private func layout() {
+        view.addSubview(tableView)
+        tableView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+    }
+
+    private func bind() {
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "Cell")
+        let input = ChatListViewModel.Input(viewDidLoad: rx.viewDidLoad.asObservable())
+        let output = viewModel.transform(input: input)
+
+        output.chats
+            .drive(tableView.rx.items(cellIdentifier: "Cell")) { _, chat, cell in
+                cell.textLabel?.text = chat.title
+            }
+            .disposed(by: disposeBag)
+
+        tableView.rx.modelSelected(Chat.self)
+            .subscribe(onNext: { [weak self] chat in
+                self?.onSelectChat?(chat)
+            })
+            .disposed(by: disposeBag)
+    }
+}

--- a/chatGPT/Presentation/Scene/ChatList/ChatListViewModel.swift
+++ b/chatGPT/Presentation/Scene/ChatList/ChatListViewModel.swift
@@ -1,0 +1,26 @@
+import Foundation
+import RxSwift
+import RxCocoa
+
+final class ChatListViewModel {
+    struct Input {
+        let viewDidLoad: Observable<Void>
+    }
+
+    struct Output {
+        let chats: Driver<[Chat]>
+    }
+
+    private let useCase: ChatUseCase
+
+    init(useCase: ChatUseCase) {
+        self.useCase = useCase
+    }
+
+    func transform(input: Input) -> Output {
+        let chats = input.viewDidLoad
+            .flatMapLatest { self.useCase.fetchChats() }
+            .asDriver(onErrorJustReturn: [])
+        return Output(chats: chats)
+    }
+}

--- a/chatGPT/Presentation/Scene/ChatViewModel.swift
+++ b/chatGPT/Presentation/Scene/ChatViewModel.swift
@@ -27,14 +27,35 @@ final class ChatViewModel {
 
     // MARK: - Dependencies
     private let sendMessageUseCase: SendChatWithContextUseCase
+    private let chatUseCase: ChatUseCase
+    private var chatID: String?
     private let disposeBag = DisposeBag()
 
-    init(sendMessageUseCase: SendChatWithContextUseCase) {
+    init(sendMessageUseCase: SendChatWithContextUseCase, chatUseCase: ChatUseCase) {
         self.sendMessageUseCase = sendMessageUseCase
+        self.chatUseCase = chatUseCase
     }
 
     func send(prompt: String, model: OpenAIModel) {
+        let userMessage = ChatRecordMessage(id: UUID().uuidString,
+                                            text: prompt,
+                                            isUser: true,
+                                            createdAt: Date())
         appendMessage(ChatMessage(type: .user, text: prompt))
+
+        if let id = chatID {
+            chatUseCase.appendMessage(chatID: id, message: userMessage)
+                .subscribe()
+                .disposed(by: disposeBag)
+        } else {
+            chatUseCase.createChat(title: prompt)
+                .flatMap { [weak self] chat -> Observable<Void> in
+                    self?.chatID = chat.id
+                    return self?.chatUseCase.appendMessage(chatID: chat.id, message: userMessage) ?? .empty()
+                }
+                .subscribe()
+                .disposed(by: disposeBag)
+        }
 
         sendMessageUseCase.execute(prompt: prompt, model: model) { [weak self] result in
             guard let self = self else { return }
@@ -42,6 +63,15 @@ final class ChatViewModel {
             switch result {
             case .success(let reply):
                 self.appendMessage(ChatMessage(type: .assistant, text: reply))
+                if let id = self.chatID {
+                    let msg = ChatRecordMessage(id: UUID().uuidString,
+                                                text: reply,
+                                                isUser: false,
+                                                createdAt: Date())
+                    self.chatUseCase.appendMessage(chatID: id, message: msg)
+                        .subscribe()
+                        .disposed(by: self.disposeBag)
+                }
 
             case .failure(let error):
                 let message = (error as? OpenAIError)?.errorMessage ?? error.localizedDescription

--- a/chatGPT/Presentation/Scene/MainViewController.swift
+++ b/chatGPT/Presentation/Scene/MainViewController.swift
@@ -62,9 +62,12 @@ final class MainViewController: UIViewController {
     // MARK: 채팅 dataSource
     private var dataSource: UITableViewDiffableDataSource<Int, ChatViewModel.ChatMessage>!
     
-    init(fetchModelsUseCase: FetchAvailableModelsUseCase, sendChatMessageUseCase: SendChatWithContextUseCase) {
+    init(fetchModelsUseCase: FetchAvailableModelsUseCase,
+         sendChatMessageUseCase: SendChatWithContextUseCase,
+         chatUseCase: ChatUseCase) {
         self.fetchModelsUseCase = fetchModelsUseCase
-        self.chatViewModel = ChatViewModel(sendMessageUseCase: sendChatMessageUseCase)
+        self.chatViewModel = ChatViewModel(sendMessageUseCase: sendChatMessageUseCase,
+                                           chatUseCase: chatUseCase)
         super.init(nibName: nil, bundle: nil)
     }
     


### PR DESCRIPTION
## Summary
- add Firestore data source and repository for chats
- add domain models and use case
- implement chat list scene
- store chat messages with ChatViewModel
- wire into AppCoordinator

## Testing
- `swift test` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6853fa9a9ffc832ba4b8943d9ebc0c91