### PR TITLE
add signout menu

### DIFF
--- a/chatGPT/Domain/UseCase/SignOutUseCase.swift
+++ b/chatGPT/Domain/UseCase/SignOutUseCase.swift
@@ -1,0 +1,6 @@
+final class SignOutUseCase {
+    private let repository: AuthRepository
+    init(repository: AuthRepository) { self.repository = repository }
+    func execute() throws { try repository.signOut() }
+}
+

--- a/chatGPT/Presentation/Coordinator/AppCoordinator.swift
+++ b/chatGPT/Presentation/Coordinator/AppCoordinator.swift
@@ -54,10 +54,12 @@ final class AppCoordinator {
             contextRepository: contextRepository,
             summarizeUseCase: summarizeUseCase
         )
-        
+        let signOutUseCase = SignOutUseCase(repository: authRepository)
+
         let vc = MainViewController(
             fetchModelsUseCase: fetchModelsUseCase,
-            sendChatMessageUseCase: sendChatUseCase
+            sendChatMessageUseCase: sendChatUseCase,
+            signOutUseCase: signOutUseCase
         )
         
         let nav = UINavigationController(rootViewController: vc)
@@ -86,3 +88,4 @@ final class AppCoordinator {
         window.makeKeyAndVisible()
     }
 }
+

--- a/chatGPT/Presentation/Scene/MenuViewController.swift
+++ b/chatGPT/Presentation/Scene/MenuViewController.swift
@@ -1,0 +1,55 @@
+import UIKit
+import SnapKit
+import RxSwift
+import RxCocoa
+
+final class MenuViewController: UIViewController {
+    private let signOutUseCase: SignOutUseCase
+    private let disposeBag = DisposeBag()
+
+    private lazy var signOutButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("로그아웃", for: .normal)
+        button.setTitleColor(ThemeColor.label1, for: .normal)
+        return button
+    }()
+
+    init(signOutUseCase: SignOutUseCase) {
+        self.signOutUseCase = signOutUseCase
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        layout()
+        bind()
+    }
+
+    private func layout() {
+        view.backgroundColor = ThemeColor.background1
+        view.addSubview(signOutButton)
+        signOutButton.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).offset(16)
+            make.leading.trailing.equalToSuperview().inset(16)
+            make.height.equalTo(44)
+        }
+    }
+
+    private func bind() {
+        signOutButton.rx.tap
+            .throttle(.milliseconds(500), scheduler: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] in
+                guard let self = self else { return }
+                do {
+                    try self.signOutUseCase.execute()
+                    self.dismiss(animated: true)
+                } catch {
+                    print("❌ Sign out failed: \(error.localizedDescription)")
+                }
+            })
+            .disposed(by: disposeBag)
+    }
+}
+


### PR DESCRIPTION
## Summary
- add SignOutUseCase for logout
- show side menu with sign out button
- wire menu via left bar button in main screen
- connect sign out use case in AppCoordinator

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_685908832e90832b8dce9a746fd1a35d