### PR TITLE
implement reactive profile image loading

### DIFF
--- a/chatGPT.xcodeproj/project.pbxproj
+++ b/chatGPT.xcodeproj/project.pbxproj
@@ -67,7 +67,11 @@
 		F1EF04EF2E044EC5005D2CF9 /* UIColor+hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1EF04EE2E044EC5005D2CF9 /* UIColor+hex.swift */; };
 		a0d99ba381b44d72b54327f6 /* MenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = e9d37b25c97b401d97ce1732 /* MenuViewController.swift */; };
 		c076797f219e4afdb2928170 /* SummarizeMessagesUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = ee987c883dab481cb2765061 /* SummarizeMessagesUseCase.swift */; };
-		ccfa5907f1434e87b23a8d58 /* SendChatWithContextUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = f495b15056fc494682c60df5 /* SendChatWithContextUseCase.swift */; };
+                ccfa5907f1434e87b23a8d58 /* SendChatWithContextUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = f495b15056fc494682c60df5 /* SendChatWithContextUseCase.swift */; };
+                98fe1440434d4c66ad46c0ca /* ImageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = c2820ff33be8404985358650 /* ImageRepository.swift */; };
+                aa711a251b034678b1e8a5c7 /* KingfisherImageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7d4726864e6840b090b6e407 /* KingfisherImageRepository.swift */; };
+                65fb6a733717417aaec1ec5b /* LoadUserProfileImageUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = eef3624df55348a684cdc5fd /* LoadUserProfileImageUseCase.swift */; };
+                d4ae3188874b4ea4a0abdef2 /* ObserveAuthStateUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9b8f82223d524f878b330338 /* ObserveAuthStateUseCase.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -141,7 +145,11 @@
 		d3ab64ef73ac4fbca561c2f3 /* ChatContextRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatContextRepositoryImpl.swift; sourceTree = "<group>"; };
 		e9d37b25c97b401d97ce1732 /* MenuViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuViewController.swift; sourceTree = "<group>"; };
 		ee987c883dab481cb2765061 /* SummarizeMessagesUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummarizeMessagesUseCase.swift; sourceTree = "<group>"; };
-		f495b15056fc494682c60df5 /* SendChatWithContextUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendChatWithContextUseCase.swift; sourceTree = "<group>"; };
+                f495b15056fc494682c60df5 /* SendChatWithContextUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendChatWithContextUseCase.swift; sourceTree = "<group>"; };
+                c2820ff33be8404985358650 /* ImageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRepository.swift; sourceTree = "<group>"; };
+                7d4726864e6840b090b6e407 /* KingfisherImageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KingfisherImageRepository.swift; sourceTree = "<group>"; };
+                eef3624df55348a684cdc5fd /* LoadUserProfileImageUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadUserProfileImageUseCase.swift; sourceTree = "<group>"; };
+                9b8f82223d524f878b330338 /* ObserveAuthStateUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObserveAuthStateUseCase.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -288,9 +296,10 @@
 				F1DE5A772E094C37001B0CA8 /* FirebaseAuthRepository.swift */,
 				F1DF3B022DF9AF7B00D8445A /* KeychainAPIKeyRepository.swift */,
 				F117E0742E0184A900D1C95F /* OpenAIRepository.swift */,
-				F117E0762E0184FF00D1C95F /* OpenAIRepositoryImpl.swift */,
-				d3ab64ef73ac4fbca561c2f3 /* ChatContextRepositoryImpl.swift */,
-			);
+                                F117E0762E0184FF00D1C95F /* OpenAIRepositoryImpl.swift */,
+                                d3ab64ef73ac4fbca561c2f3 /* ChatContextRepositoryImpl.swift */,
+                                7d4726864e6840b090b6e407 /* KingfisherImageRepository.swift */,
+                        );
 			path = Data;
 			sourceTree = "<group>";
 		};
@@ -309,9 +318,10 @@
 			isa = PBXGroup;
 			children = (
 				F1DE5A752E094BD6001B0CA8 /* AuthRepository.swift */,
-				F1DF3B092DF9B01100D8445A /* ApiKeyRepository.swift */,
-				3523b66a0b6a4beab384ad00 /* ChatContextRepository.swift */,
-			);
+                                F1DF3B092DF9B01100D8445A /* ApiKeyRepository.swift */,
+                                3523b66a0b6a4beab384ad00 /* ChatContextRepository.swift */,
+                                c2820ff33be8404985358650 /* ImageRepository.swift */,
+                        );
 			path = Repository;
 			sourceTree = "<group>";
 		};
@@ -323,10 +333,12 @@
 				F1DF3B102DF9B06500D8445A /* SaveAPIKeyUseCase.swift */,
 				F117E0722E01847E00D1C95F /* FetchAvailableModelsUseCase.swift */,
 				F117E0782E0185D100D1C95F /* SendChatMessageUseCase.swift */,
-				ee987c883dab481cb2765061 /* SummarizeMessagesUseCase.swift */,
-				f495b15056fc494682c60df5 /* SendChatWithContextUseCase.swift */,
-				896db1fb7f9843dbb43a9831 /* SignOutUseCase.swift */,
-			);
+                                ee987c883dab481cb2765061 /* SummarizeMessagesUseCase.swift */,
+                                f495b15056fc494682c60df5 /* SendChatWithContextUseCase.swift */,
+                                896db1fb7f9843dbb43a9831 /* SignOutUseCase.swift */,
+                                eef3624df55348a684cdc5fd /* LoadUserProfileImageUseCase.swift */,
+                                9b8f82223d524f878b330338 /* ObserveAuthStateUseCase.swift */,
+                        );
 			path = UseCase;
 			sourceTree = "<group>";
 		};
@@ -581,8 +593,12 @@
 				7a337f8c2fb34958a419528f /* ChatContextRepository.swift in Sources */,
 				0c7e02c4d6224d4b86698d20 /* ChatContextRepositoryImpl.swift in Sources */,
 				c076797f219e4afdb2928170 /* SummarizeMessagesUseCase.swift in Sources */,
-				ccfa5907f1434e87b23a8d58 /* SendChatWithContextUseCase.swift in Sources */,
-				F166CA132DF9A39B00AAB5B0 /* AppDelegate.swift in Sources */,
+                                ccfa5907f1434e87b23a8d58 /* SendChatWithContextUseCase.swift in Sources */,
+                                98fe1440434d4c66ad46c0ca /* ImageRepository.swift in Sources */,
+                                aa711a251b034678b1e8a5c7 /* KingfisherImageRepository.swift in Sources */,
+                                65fb6a733717417aaec1ec5b /* LoadUserProfileImageUseCase.swift in Sources */,
+                                d4ae3188874b4ea4a0abdef2 /* ObserveAuthStateUseCase.swift in Sources */,
+                                F166CA132DF9A39B00AAB5B0 /* AppDelegate.swift in Sources */,
 				F117E0752E0184A900D1C95F /* OpenAIRepository.swift in Sources */,
 				F1DF3B1D2DF9B42700D8445A /* ThemeColor.swift in Sources */,
 				F1DF3B112DF9B06500D8445A /* SaveAPIKeyUseCase.swift in Sources */,

--- a/chatGPT/Data/KingfisherImageRepository.swift
+++ b/chatGPT/Data/KingfisherImageRepository.swift
@@ -1,0 +1,19 @@
+import UIKit
+import RxSwift
+import Kingfisher
+
+final class KingfisherImageRepository: ImageRepository {
+    func fetchImage(from url: URL) -> Single<UIImage> {
+        Single.create { single in
+            let task = KingfisherManager.shared.retrieveImage(with: url) { result in
+                switch result {
+                case .success(let value):
+                    single(.success(value.image))
+                case .failure(let error):
+                    single(.failure(error))
+                }
+            }
+            return Disposables.create { task?.cancel() }
+        }
+    }
+}

--- a/chatGPT/Domain/Repository/ImageRepository.swift
+++ b/chatGPT/Domain/Repository/ImageRepository.swift
@@ -1,0 +1,6 @@
+import UIKit
+import RxSwift
+
+protocol ImageRepository {
+    func fetchImage(from url: URL) -> Single<UIImage>
+}

--- a/chatGPT/Domain/UseCase/LoadUserProfileImageUseCase.swift
+++ b/chatGPT/Domain/UseCase/LoadUserProfileImageUseCase.swift
@@ -1,0 +1,23 @@
+import UIKit
+import RxSwift
+
+final class LoadUserProfileImageUseCase {
+    private let imageRepository: ImageRepository
+    private let getCurrentUserUseCase: GetCurrentUserUseCase
+
+    init(imageRepository: ImageRepository, getCurrentUserUseCase: GetCurrentUserUseCase) {
+        self.imageRepository = imageRepository
+        self.getCurrentUserUseCase = getCurrentUserUseCase
+    }
+
+    func execute() -> Single<UIImage> {
+        guard let user = getCurrentUserUseCase.execute(), let url = user.photoURL else {
+            return .error(ImageError.missingURL)
+        }
+        return imageRepository.fetchImage(from: url)
+    }
+}
+
+enum ImageError: Error {
+    case missingURL
+}

--- a/chatGPT/Domain/UseCase/ObserveAuthStateUseCase.swift
+++ b/chatGPT/Domain/UseCase/ObserveAuthStateUseCase.swift
@@ -1,0 +1,7 @@
+import RxSwift
+
+final class ObserveAuthStateUseCase {
+    private let repository: AuthRepository
+    init(repository: AuthRepository) { self.repository = repository }
+    func execute() -> Observable<AuthUser?> { repository.observeAuthState() }
+}

--- a/chatGPT/Presentation/Coordinator/AppCoordinator.swift
+++ b/chatGPT/Presentation/Coordinator/AppCoordinator.swift
@@ -56,12 +56,19 @@ final class AppCoordinator {
         )
         let signOutUseCase = SignOutUseCase(repository: authRepository)
         let getCurrentUserUseCase = GetCurrentUserUseCase(repository: authRepository)
+        let imageRepository = KingfisherImageRepository()
+        let loadUserImageUseCase = LoadUserProfileImageUseCase(
+            imageRepository: imageRepository,
+            getCurrentUserUseCase: getCurrentUserUseCase
+        )
+        let observeAuthStateUseCase = ObserveAuthStateUseCase(repository: authRepository)
 
         let vc = MainViewController(
             fetchModelsUseCase: fetchModelsUseCase,
             sendChatMessageUseCase: sendChatUseCase,
             signOutUseCase: signOutUseCase,
-            getCurrentUserUseCase: getCurrentUserUseCase
+            loadUserImageUseCase: loadUserImageUseCase,
+            observeAuthStateUseCase: observeAuthStateUseCase
         )
         
         let nav = UINavigationController(rootViewController: vc)


### PR DESCRIPTION
## Summary
- add repository and usecases for profile image
- refactor MainViewController to load profile image reactively
- inject new dependencies via AppCoordinator
- include new files in Xcode project

## Testing
- `swift test` *(fails: target 'chatGPTTests' has overlapping sources)*

------
https://chatgpt.com/codex/tasks/task_e_6859500fd454832bb8d20141114fefe7