### PR TITLE
update auth state usecase

### DIFF
--- a/chatGPT/Domain/UseCase/ObserveAuthStateUseCase.swift
+++ b/chatGPT/Domain/UseCase/ObserveAuthStateUseCase.swift
@@ -3,5 +3,8 @@ import RxSwift
 final class ObserveAuthStateUseCase {
     private let repository: AuthRepository
     init(repository: AuthRepository) { self.repository = repository }
-    func execute() -> Observable<AuthUser?> { repository.observeAuthState() }
+    func execute() -> Observable<AuthUser?> {
+        repository.observeAuthState()
+            .distinctUntilChanged { $0?.uid == $1?.uid }
+    }
 }


### PR DESCRIPTION
## Summary
- ensure auth state change only triggers on UID change

## Testing
- `swift test` *(fails: overlapping sources)*

------
https://chatgpt.com/codex/tasks/task_e_685955403220832b928a6d6ea192f7c8