### PR TITLE
implement firestore conversation

### DIFF
--- a/chatGPT/Data/FirestoreConversationRepository.swift
+++ b/chatGPT/Data/FirestoreConversationRepository.swift
@@ -1,0 +1,40 @@
+import Foundation
+import FirebaseFirestore
+import RxSwift
+
+final class FirestoreConversationRepository: ConversationRepository {
+    private let db = Firestore.firestore()
+
+    func createConversation(uid: String,
+                            title: String,
+                            question: String,
+                            answer: String,
+                            timestamp: Date) -> Single<Void> {
+        Single.create { single in
+            let conversationID = UUID().uuidString
+            let data: [String: Any] = [
+                "title": title,
+                "messages": [
+                    [
+                        "role": "user",
+                        "text": question,
+                        "timestamp": Timestamp(date: timestamp)
+                    ],
+                    [
+                        "role": "assistant",
+                        "text": answer,
+                        "timestamp": Timestamp(date: timestamp)
+                    ]
+                ]
+            ]
+            self.db.collection(uid).document(conversationID).setData(data) { error in
+                if let error = error {
+                    single(.failure(error))
+                } else {
+                    single(.success(()))
+                }
+            }
+            return Disposables.create()
+        }
+    }
+}

--- a/chatGPT/Domain/Entity/ConversationMessage.swift
+++ b/chatGPT/Domain/Entity/ConversationMessage.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct ConversationMessage: Codable {
+    let role: RoleType
+    let text: String
+    let timestamp: Date
+}

--- a/chatGPT/Domain/Repository/ConversationRepository.swift
+++ b/chatGPT/Domain/Repository/ConversationRepository.swift
@@ -1,0 +1,10 @@
+import Foundation
+import RxSwift
+
+protocol ConversationRepository {
+    func createConversation(uid: String,
+                            title: String,
+                            question: String,
+                            answer: String,
+                            timestamp: Date) -> Single<Void>
+}

--- a/chatGPT/Domain/UseCase/SaveConversationUseCase.swift
+++ b/chatGPT/Domain/UseCase/SaveConversationUseCase.swift
@@ -1,0 +1,31 @@
+import Foundation
+import RxSwift
+
+final class SaveConversationUseCase {
+    private let repository: ConversationRepository
+    private let getCurrentUserUseCase: GetCurrentUserUseCase
+
+    init(repository: ConversationRepository,
+         getCurrentUserUseCase: GetCurrentUserUseCase) {
+        self.repository = repository
+        self.getCurrentUserUseCase = getCurrentUserUseCase
+    }
+
+    func execute(title: String,
+                 question: String,
+                 answer: String,
+                 timestamp: Date = Date()) -> Single<Void> {
+        guard let user = getCurrentUserUseCase.execute() else {
+            return .error(ConversationError.noUser)
+        }
+        return repository.createConversation(uid: user.uid,
+                                             title: title,
+                                             question: question,
+                                             answer: answer,
+                                             timestamp: timestamp)
+    }
+}
+
+enum ConversationError: Error {
+    case noUser
+}

--- a/chatGPT/Presentation/Coordinator/AppCoordinator.swift
+++ b/chatGPT/Presentation/Coordinator/AppCoordinator.swift
@@ -54,8 +54,13 @@ final class AppCoordinator {
             contextRepository: contextRepository,
             summarizeUseCase: summarizeUseCase
         )
-        let signOutUseCase = SignOutUseCase(repository: authRepository)
+        let conversationRepository = FirestoreConversationRepository()
         let getCurrentUserUseCase = GetCurrentUserUseCase(repository: authRepository)
+        let saveConversationUseCase = SaveConversationUseCase(
+            repository: conversationRepository,
+            getCurrentUserUseCase: getCurrentUserUseCase
+        )
+        let signOutUseCase = SignOutUseCase(repository: authRepository)
         let imageRepository = KingfisherImageRepository()
         let loadUserImageUseCase = LoadUserProfileImageUseCase(
             imageRepository: imageRepository,
@@ -66,6 +71,8 @@ final class AppCoordinator {
         let vc = MainViewController(
             fetchModelsUseCase: fetchModelsUseCase,
             sendChatMessageUseCase: sendChatUseCase,
+            summarizeUseCase: summarizeUseCase,
+            saveConversationUseCase: saveConversationUseCase,
             signOutUseCase: signOutUseCase,
             loadUserImageUseCase: loadUserImageUseCase,
             observeAuthStateUseCase: observeAuthStateUseCase

--- a/chatGPT/Presentation/Scene/MainViewController.swift
+++ b/chatGPT/Presentation/Scene/MainViewController.swift
@@ -85,11 +85,15 @@ final class MainViewController: UIViewController {
     
     init(fetchModelsUseCase: FetchAvailableModelsUseCase,
          sendChatMessageUseCase: SendChatWithContextUseCase,
+         summarizeUseCase: SummarizeMessagesUseCase,
+         saveConversationUseCase: SaveConversationUseCase,
          signOutUseCase: SignOutUseCase,
          loadUserImageUseCase: LoadUserProfileImageUseCase,
          observeAuthStateUseCase: ObserveAuthStateUseCase) {
         self.fetchModelsUseCase = fetchModelsUseCase
-        self.chatViewModel = ChatViewModel(sendMessageUseCase: sendChatMessageUseCase)
+        self.chatViewModel = ChatViewModel(sendMessageUseCase: sendChatMessageUseCase,
+                                           summarizeUseCase: summarizeUseCase,
+                                           saveConversationUseCase: saveConversationUseCase)
         self.signOutUseCase = signOutUseCase
         self.loadUserImageUseCase = loadUserImageUseCase
         self.observeAuthStateUseCase = observeAuthStateUseCase


### PR DESCRIPTION
## Summary
- add conversation entity and repo
- support saving conversation with Firestore
- store first chat via ChatViewModel
- update coordinator and view controller setup

## Testing
- `swift build -c release` *(fails: defaultLocalization not set)*
- `swift test` *(fails: defaultLocalization not set)*

------
https://chatgpt.com/codex/tasks/task_e_685959a91a90832bbd9e262775899fb9