### PR TITLE
refactor message flow

### DIFF
--- a/chatGPT/Domain/Repository/ConversationRepository.swift
+++ b/chatGPT/Domain/Repository/ConversationRepository.swift
@@ -12,4 +12,6 @@ protocol ConversationRepository {
                        role: RoleType,
                        text: String,
                        timestamp: Date) -> Single<Void>
+    func observeMessages(uid: String,
+                         conversationID: String) -> Observable<[ConversationMessage]>
 }

--- a/chatGPT/Domain/UseCase/ObserveConversationMessagesUseCase.swift
+++ b/chatGPT/Domain/UseCase/ObserveConversationMessagesUseCase.swift
@@ -1,0 +1,20 @@
+import Foundation
+import RxSwift
+
+final class ObserveConversationMessagesUseCase {
+    private let repository: ConversationRepository
+    private let getCurrentUserUseCase: GetCurrentUserUseCase
+
+    init(repository: ConversationRepository,
+         getCurrentUserUseCase: GetCurrentUserUseCase) {
+        self.repository = repository
+        self.getCurrentUserUseCase = getCurrentUserUseCase
+    }
+
+    func execute(conversationID: String) -> Observable<[ConversationMessage]> {
+        guard let user = getCurrentUserUseCase.execute() else {
+            return .error(ConversationError.noUser)
+        }
+        return repository.observeMessages(uid: user.uid, conversationID: conversationID)
+    }
+}

--- a/chatGPT/Presentation/Coordinator/AppCoordinator.swift
+++ b/chatGPT/Presentation/Coordinator/AppCoordinator.swift
@@ -64,6 +64,10 @@ final class AppCoordinator {
             repository: conversationRepository,
             getCurrentUserUseCase: getCurrentUserUseCase
         )
+        let observeMessagesUseCase = ObserveConversationMessagesUseCase(
+            repository: conversationRepository,
+            getCurrentUserUseCase: getCurrentUserUseCase
+        )
         let signOutUseCase = SignOutUseCase(repository: authRepository)
         let imageRepository = KingfisherImageRepository()
         let loadUserImageUseCase = LoadUserProfileImageUseCase(
@@ -78,6 +82,7 @@ final class AppCoordinator {
             summarizeUseCase: summarizeUseCase,
             saveConversationUseCase: saveConversationUseCase,
             appendMessageUseCase: appendMessageUseCase,
+            observeMessagesUseCase: observeMessagesUseCase,
             signOutUseCase: signOutUseCase,
             loadUserImageUseCase: loadUserImageUseCase,
             observeAuthStateUseCase: observeAuthStateUseCase


### PR DESCRIPTION
## Summary
- observe chat messages from Firestore instead of local state
- add use case to watch Firestore updates
- expose conversation ID from `ChatViewModel`
- update coordinator and controller for new flow

## Testing
- `swift build` *(fails: manifest requires defaultLocalization)*
- `swift test` *(fails: manifest requires defaultLocalization)*

------
https://chatgpt.com/codex/tasks/task_e_685a7c75ba74832bbe6177a9e9789a79