### PR TITLE
fix model picker view alert

### DIFF
--- a/chatGPT/Presentation/Scene/MenuViewController.swift
+++ b/chatGPT/Presentation/Scene/MenuViewController.swift
@@ -135,8 +135,10 @@ final class MenuViewController: UIViewController {
                 self.tableView.reloadRows(at: [index], with: .automatic)
             }
             alert.addAction(action)
+        }
         alert.addAction(UIAlertAction(title: "취소", style: .cancel))
         present(alert, animated: true)
+    }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         switch Section(rawValue: section) {
@@ -175,13 +177,4 @@ final class MenuViewController: UIViewController {
     }
 }
 
-extension MenuViewController: UIPickerViewDataSource, UIPickerViewDelegate {
-    func numberOfComponents(in pickerView: UIPickerView) -> Int { 1 }
-    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
-        availableModels.count
-    }
-    func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
-        availableModels[row].displayName
-    }
-}
 


### PR DESCRIPTION
## Summary
- fix missing braces in `presentModelSelector`
- remove unused UIPickerView delegate extension

## Testing
- `swift test -l` *(fails: manifest property 'defaultLocalization' not set)*
- `swift build` *(fails: manifest property 'defaultLocalization' not set)*

------
https://chatgpt.com/codex/tasks/task_e_685bb601fc80832bb0436d2a6416d1e2