### PR TITLE
fix conversation reset

### DIFF
--- a/chatGPT/Domain/UseCase/SendChatWithContextUseCase.swift
+++ b/chatGPT/Domain/UseCase/SendChatWithContextUseCase.swift
@@ -49,6 +49,10 @@ final class SendChatWithContextUseCase {
         }
     }
 
+    func clearContext() {
+        contextRepository.clear()
+    }
+
     private func summarizeIfNeeded(model: OpenAIModel) {
         let count = contextRepository.messages.count
         guard count > summaryTrigger else { return }

--- a/chatGPT/Presentation/Scene/ChatViewModel.swift
+++ b/chatGPT/Presentation/Scene/ChatViewModel.swift
@@ -109,5 +109,6 @@ final class ChatViewModel {
     func startNewConversation() {
         messages.accept([])
         conversationIDRelay.accept(nil)
+        sendMessageUseCase.clearContext()
     }
 }


### PR DESCRIPTION
## Summary
- clear chat context when starting a new conversation
- expose `clearContext` on `SendChatWithContextUseCase`

## Testing
- `swift test -l` *(fails: manifest property `defaultLocalization` not set)*

------
https://chatgpt.com/codex/tasks/task_e_685bc5cd08c0832b93186482c41b6731