### PR TITLE
disable animations on conversation switch

### DIFF
--- a/chatGPT/Presentation/Scene/ChatViewModel.swift
+++ b/chatGPT/Presentation/Scene/ChatViewModel.swift
@@ -24,6 +24,7 @@ final class ChatViewModel {
 
     // MARK: - Output
     let messages = BehaviorRelay<[ChatMessage]>(value: [])
+    let conversationChanged = PublishRelay<Void>()
 
     // MARK: - Dependencies
     private let sendMessageUseCase: SendChatWithContextUseCase
@@ -118,6 +119,7 @@ final class ChatViewModel {
     }
 
     func startNewConversation() {
+        conversationChanged.accept(())
         draftMessages = []
         messages.accept([])
         conversationIDRelay.accept(nil)
@@ -125,6 +127,7 @@ final class ChatViewModel {
     }
 
     func resumeDraftConversation() {
+        conversationChanged.accept(())
         messages.accept(draftMessages ?? [])
         conversationIDRelay.accept(nil)
         sendMessageUseCase.clearContext()
@@ -141,6 +144,7 @@ final class ChatViewModel {
                 let chatMessages = list.map { item in
                     ChatMessage(type: item.role == .user ? .user : .assistant, text: item.text)
                 }
+                self.conversationChanged.accept(())
                 self.messages.accept(chatMessages)
                 self.conversationIDRelay.accept(id)
                 let msgs = list.map { Message(role: $0.role, content: $0.text) }

--- a/chatGPT/Presentation/Scene/MainViewController.swift
+++ b/chatGPT/Presentation/Scene/MainViewController.swift
@@ -105,6 +105,8 @@ final class MainViewController: UIViewController {
     
     // MARK: 채팅 dataSource
     private var dataSource: UITableViewDiffableDataSource<Int, ChatViewModel.ChatMessage>!
+
+    private var animateDifferences = true
     
     init(fetchModelsUseCase: FetchAvailableModelsUseCase,
          sendChatMessageUseCase: SendChatWithContextUseCase,
@@ -195,6 +197,13 @@ final class MainViewController: UIViewController {
                 self?.applySnapshot(messages)
             })
             .disposed(by: disposeBag)
+
+        chatViewModel.conversationChanged
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] in
+                self?.animateDifferences = false
+            })
+            .disposed(by: disposeBag)
         
         menuBarButton.rx.tap
             .throttle(.milliseconds(500), scheduler: MainScheduler.instance)
@@ -243,7 +252,8 @@ final class MainViewController: UIViewController {
         // 💡 transform이 적용된 상태에서는 reversed된 순서로 추가해야 아래부터 쌓임
         snapshot.appendItems(messages.reversed())
         
-        dataSource.apply(snapshot, animatingDifferences: true)
+        dataSource.apply(snapshot, animatingDifferences: animateDifferences)
+        animateDifferences = true
         
         if !messages.isEmpty {
             let indexPath = IndexPath(row: 0, section: 0) // ⬅️ 가장 아래쪽 셀로 스크롤


### PR DESCRIPTION
## Summary
- fire `conversationChanged` when starting, resuming or loading chat
- update MainViewController to apply snapshots without animation after switching

## Testing
- `swift test -v` *(fails: manifest property `defaultLocalization` not set)*

------
https://chatgpt.com/codex/tasks/task_e_685bcc4d3190832b9edc9d9f8c3d3284