### PR TITLE
remove quotes

### DIFF
--- a/chatGPT/Presentation/Helpers/String+Sanitize.swift
+++ b/chatGPT/Presentation/Helpers/String+Sanitize.swift
@@ -1,0 +1,15 @@
+//
+//  String+Sanitize.swift
+//  chatGPT
+//
+//  Created by Codex.
+//
+
+import Foundation
+
+extension String {
+    /// Removes single and double quotes from the string
+    func removingQuotes() -> String {
+        self.replacingOccurrences(of: "\"", with: "").replacingOccurrences(of: "'", with: "")
+    }
+}

--- a/chatGPT/Presentation/Scene/ChatViewModel.swift
+++ b/chatGPT/Presentation/Scene/ChatViewModel.swift
@@ -102,7 +102,8 @@ final class ChatViewModel {
         summarizeUseCase.execute(messages: history, model: model) { [weak self] result in
             guard let self = self else { return }
             if case .success(let title) = result {
-                self.saveConversationUseCase.execute(title: title, question: question, answer: answer)
+                let cleanTitle = title.removingQuotes()
+                self.saveConversationUseCase.execute(title: cleanTitle, question: question, answer: answer)
                     .subscribe(onSuccess: { [weak self] id in
                         self?.conversationIDRelay.accept(id)
                         self?.draftMessages = nil


### PR DESCRIPTION
## Summary
- sanitize conversation titles by removing single and double quotes
- add helper to strip quotes from strings

## Testing
- `swift test --disable-index-store` *(fails: manifest property 'defaultLocalization' not set)*

------
https://chatgpt.com/codex/tasks/task_e_685bd65c7818832b8cf21a311ec1dbf0