### PR TITLE
Add streaming support

### DIFF
--- a/chatGPT/Data/OpenAIRepository.swift
+++ b/chatGPT/Data/OpenAIRepository.swift
@@ -6,8 +6,10 @@
 //
 
 import Foundation
+import RxSwift
 
 protocol OpenAIRepository {
     func fetchAvailableModels(completion: @escaping (Result<[OpenAIModel], Error>) -> Void)
     func sendChat(messages: [Message], model: OpenAIModel, stream: Bool, completion: @escaping (Result<String, Error>) -> Void)
+    func sendChatStream(messages: [Message], model: OpenAIModel) -> Observable<String>
 }

--- a/chatGPT/Data/OpenAIRepositoryImpl.swift
+++ b/chatGPT/Data/OpenAIRepositoryImpl.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import RxSwift
 
 final class OpenAIRepositoryImpl: OpenAIRepository {
     private let service: OpenAIService
@@ -25,6 +26,10 @@ final class OpenAIRepositoryImpl: OpenAIRepository {
                 completion(.failure(error))
             }
         }
+    }
+
+    func sendChatStream(messages: [Message], model: OpenAIModel) -> Observable<String> {
+        service.requestStream(.chat(messages: messages, model: model, stream: true))
     }
     
     /// 사용가능한 모델 조회

--- a/chatGPT/Domain/Entity/OpenAIStreamResponse.swift
+++ b/chatGPT/Domain/Entity/OpenAIStreamResponse.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct OpenAIStreamResponse: Decodable {
+    struct Choice: Decodable {
+        struct Delta: Decodable {
+            let content: String?
+        }
+        let delta: Delta
+        let finishReason: String?
+
+        enum CodingKeys: String, CodingKey {
+            case delta
+            case finishReason = "finish_reason"
+        }
+    }
+    let choices: [Choice]
+}

--- a/chatGPT/Presentation/Scene/ChatViewModel.swift
+++ b/chatGPT/Presentation/Scene/ChatViewModel.swift
@@ -17,9 +17,15 @@ final class ChatViewModel {
     }
 
     struct ChatMessage: Hashable, Identifiable {
-        let id = UUID()
+        let id: UUID
         let type: MessageType
         let text: String
+
+        init(id: UUID = UUID(), type: MessageType, text: String) {
+            self.id = id
+            self.type = type
+            self.text = text
+        }
     }
 
     // MARK: - Output
@@ -69,28 +75,60 @@ final class ChatViewModel {
                 .disposed(by: disposeBag)
         }
 
-        sendMessageUseCase.execute(prompt: prompt, model: model, stream: stream) { [weak self] result in
-            guard let self = self else { return }
+        guard stream else {
+            sendMessageUseCase.execute(prompt: prompt, model: model, stream: false) { [weak self] result in
+                guard let self = self else { return }
 
-            switch result {
-            case .success(let reply):
-                self.appendMessage(ChatMessage(type: .assistant, text: reply))
+                switch result {
+                case .success(let reply):
+                    self.appendMessage(ChatMessage(type: .assistant, text: reply))
+                    if let id = self.conversationID, !isFirst {
+                        self.appendMessageUseCase.execute(conversationID: id,
+                                                         role: .assistant,
+                                                         text: reply)
+                            .subscribe()
+                            .disposed(by: self.disposeBag)
+                    }
+                    if isFirst {
+                        self.saveFirstConversation(question: prompt, answer: reply, model: model)
+                    }
+
+                case .failure(let error):
+                    let message = (error as? OpenAIError)?.errorMessage ?? error.localizedDescription
+                    self.appendMessage(ChatMessage(type: .error, text: message))
+                }
+            }
+            return
+        }
+
+        let assistantID = UUID()
+        appendMessage(ChatMessage(id: assistantID, type: .assistant, text: ""))
+        var fullText = ""
+
+        sendMessageUseCase.stream(prompt: prompt, model: model)
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] chunk in
+                guard let self else { return }
+                fullText += chunk
+                self.updateMessage(id: assistantID, text: fullText)
+            }, onError: { [weak self] error in
+                let message = (error as? OpenAIError)?.errorMessage ?? error.localizedDescription
+                self?.updateMessage(id: assistantID, text: message, type: .error)
+            }, onCompleted: { [weak self] in
+                guard let self else { return }
+                self.sendMessageUseCase.finalize(prompt: prompt, reply: fullText, model: model)
                 if let id = self.conversationID, !isFirst {
                     self.appendMessageUseCase.execute(conversationID: id,
                                                      role: .assistant,
-                                                     text: reply)
+                                                     text: fullText)
                         .subscribe()
                         .disposed(by: self.disposeBag)
                 }
                 if isFirst {
-                    self.saveFirstConversation(question: prompt, answer: reply, model: model)
+                    self.saveFirstConversation(question: prompt, answer: fullText, model: model)
                 }
-
-            case .failure(let error):
-                let message = (error as? OpenAIError)?.errorMessage ?? error.localizedDescription
-                self.appendMessage(ChatMessage(type: .error, text: message))
-            }
-        }
+            })
+            .disposed(by: disposeBag)
     }
 
     private func saveFirstConversation(question: String, answer: String, model: OpenAIModel) {
@@ -116,6 +154,15 @@ final class ChatViewModel {
     private func appendMessage(_ message: ChatMessage) {
         var current = messages.value
         current.append(message)
+        messages.accept(current)
+    }
+
+    private func updateMessage(id: UUID, text: String, type: MessageType? = nil) {
+        var current = messages.value
+        guard let index = current.firstIndex(where: { $0.id == id }) else { return }
+        let old = current[index]
+        let newMsg = ChatMessage(id: old.id, type: type ?? old.type, text: text)
+        current[index] = newMsg
         messages.accept(current)
     }
 

--- a/chatGPT/Service/OpenAIService.swift
+++ b/chatGPT/Service/OpenAIService.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Alamofire
+import RxSwift
 
 final class OpenAIService {
     private let session: Session
@@ -60,5 +61,73 @@ final class OpenAIService {
                     completion(.failure(error as Error))
                 }
             }
+    }
+
+    func requestStream(_ endpoint: OpenAIEndpoint) -> Observable<String> {
+        Observable.create { observer in
+            guard let apiKey = apiKeyRepository.fetchKey() else {
+                observer.onError(OpenAIError.missingAPIKey)
+                return Disposables.create()
+            }
+
+            guard let url = URL(string: baseURL + endpoint.path) else {
+                observer.onError(OpenAIError.invalidURL)
+                return Disposables.create()
+            }
+
+            var headers = endpoint.headers
+            headers.add(name: "Authorization", value: "Bearer \(apiKey)")
+
+            let request: DataStreamRequest
+            if let body = endpoint.encodableBody {
+                request = session.streamRequest(
+                    url,
+                    method: endpoint.method,
+                    parameters: body,
+                    encoder: .json,
+                    headers: headers
+                )
+            } else {
+                request = session.streamRequest(
+                    url,
+                    method: endpoint.method,
+                    headers: headers
+                )
+            }
+
+            request.validate().responseStream { stream in
+                switch stream.event {
+                case let .stream(result):
+                    switch result {
+                    case let .success(data):
+                        if let chunk = String(data: data, encoding: .utf8) {
+                            for line in chunk.split(separator: "\n") {
+                                guard line.hasPrefix("data: ") else { continue }
+                                let jsonString = line.dropFirst(6)
+                                if jsonString == "[DONE]" {
+                                    observer.onCompleted()
+                                    return
+                                }
+                                if let jsonData = jsonString.data(using: .utf8),
+                                   let response = try? JSONDecoder().decode(OpenAIStreamResponse.self, from: jsonData),
+                                   let content = response.choices.first?.delta.content {
+                                    observer.onNext(content)
+                                }
+                            }
+                        }
+                    case let .failure(error):
+                        observer.onError(error)
+                    }
+                case let .complete(completion):
+                    if let error = completion.error {
+                        observer.onError(error)
+                    } else {
+                        observer.onCompleted()
+                    }
+                }
+            }
+
+            return Disposables.create { request.cancel() }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- handle SSE responses with `requestStream`
- expose `sendChatStream` in repository
- support streaming in use cases
- update view model to show streamed chunks
- add stream response entity

## Testing
- `swift test` *(fails: manifest property 'defaultLocalization' not set)*

------
https://chatgpt.com/codex/tasks/task_e_685cf6657000832b9d916e42223441d7