### PR TITLE
Enable dynamic colors

### DIFF
--- a/chatGPT/Presentation/Helpers/UIColor+Dynamic.swift
+++ b/chatGPT/Presentation/Helpers/UIColor+Dynamic.swift
@@ -1,0 +1,13 @@
+import UIKit
+
+extension UIColor {
+    static func dynamic(light: UIColor, dark: UIColor) -> UIColor {
+        if #available(iOS 13.0, *) {
+            return UIColor { trait in
+                trait.userInterfaceStyle == .dark ? dark : light
+            }
+        } else {
+            return light
+        }
+    }
+}

--- a/chatGPT/Resource/ThemeColor.swift
+++ b/chatGPT/Resource/ThemeColor.swift
@@ -8,43 +8,43 @@
 import UIKit
 
 struct ThemeColor {
-    
-    ///대표1 (255, 255, 255)
-    static let tintPrimary: UIColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
-    
-    ///대표2 (255, 255, 255)
-    static let tintSecondary: UIColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
-    
-    ///대표3 (255, 255, 255)
-    static let tintTertiary: UIColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
-    
-    ///비활성화(49, 50, 57)
-    static let tintDisable: UIColor = #colorLiteral(red: 0.1921568627, green: 0.1960784314, blue: 0.2235294118, alpha: 1)
-    
-    ///짙은 검은색 (15,15, 15)
-    static let tintDark: UIColor = #colorLiteral(red: 0.05882352941, green: 0.05882352941, blue: 0.05882352941, alpha: 1)
-    
-    ///라벨1 (45, 45, 45)
-    static let label1: UIColor = #colorLiteral(red: 0.1764705882, green: 0.1764705882, blue: 0.1764705882, alpha: 1)
-    
-    ///라벨2 (147, 147, 147)
-    static let label2: UIColor = #colorLiteral(red: 0.5764705882, green: 0.5764705882, blue: 0.5764705882, alpha: 1)
-    
-    ///라벨3 (239, 239, 239)
-    static let label3: UIColor = #colorLiteral(red: 0.937254902, green: 0.937254902, blue: 0.937254902, alpha: 1)
-    
-    ///배경1 (255, 255, 255)
-    static let background1: UIColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
-    
-    ///배경2 (251, 250, 250)
-    static let background2: UIColor = #colorLiteral(red: 0.9843137255, green: 0.9803921569, blue: 0.9803921569, alpha: 1)
-    
-    ///배경2 (222, 226, 230)
-    static let background3: UIColor = #colorLiteral(red: 0.8705882353, green: 0.8862745098, blue: 0.9019607843, alpha: 1)
-    
-    ///긍정 (18, 97, 196)
-    static let positive: UIColor = #colorLiteral(red: 0.07058823529, green: 0.3803921569, blue: 0.768627451, alpha: 1)
-    
-    ///부정 (200, 74, 49)
-    static let nagative: UIColor = #colorLiteral(red: 0.7843137255, green: 0.2901960784, blue: 0.1921568627, alpha: 1)
+    static var tintPrimary: UIColor {
+        .dynamic(light: .white, dark: .white)
+    }
+    static var tintSecondary: UIColor {
+        .dynamic(light: .white, dark: UIColor(hex: "#D1D1D1"))
+    }
+    static var tintTertiary: UIColor {
+        .dynamic(light: .white, dark: UIColor(hex: "#989898"))
+    }
+    static var tintDisable: UIColor {
+        .dynamic(light: UIColor(hex: "#313239"), dark: .darkGray)
+    }
+    static var tintDark: UIColor {
+        .dynamic(light: UIColor(hex: "#0F0F0F"), dark: .white)
+    }
+    static var label1: UIColor {
+        .dynamic(light: UIColor(hex: "#2D2D2D"), dark: .white)
+    }
+    static var label2: UIColor {
+        .dynamic(light: UIColor(hex: "#939393"), dark: UIColor(hex: "#A0A0A0"))
+    }
+    static var label3: UIColor {
+        .dynamic(light: UIColor(hex: "#EFEFEF"), dark: UIColor(hex: "#1F1F1F"))
+    }
+    static var background1: UIColor {
+        .dynamic(light: .white, dark: .black)
+    }
+    static var background2: UIColor {
+        .dynamic(light: UIColor(hex: "#FBFAFA"), dark: UIColor(hex: "#1D1D1D"))
+    }
+    static var background3: UIColor {
+        .dynamic(light: UIColor(hex: "#DEE2E6"), dark: UIColor(hex: "#2C2C2E"))
+    }
+    static var positive: UIColor {
+        .dynamic(light: UIColor(hex: "#1261C4"), dark: UIColor(hex: "#0A84FF"))
+    }
+    static var nagative: UIColor {
+        .dynamic(light: UIColor(hex: "#C84A31"), dark: UIColor(hex: "#FF453A"))
+    }
 }


### PR DESCRIPTION
## Summary
- support light/dark mode by adding a helper to create dynamic colors
- update `ThemeColor` to return adaptive colors

## Testing
- `swift test` *(fails: manifest property `defaultLocalization` not set)*

------
https://chatgpt.com/codex/tasks/task_e_685d04f35484832b9dd058e96d7d4797