### PR TITLE
Fix chat order

### DIFF
--- a/chatGPT/Presentation/Scene/Cells/ChatMessageCell.swift
+++ b/chatGPT/Presentation/Scene/Cells/ChatMessageCell.swift
@@ -53,8 +53,6 @@ final class ChatMessageCell: UITableViewCell {
 
     func configure(with message: ChatViewModel.ChatMessage) {
 
-        self.contentView.transform = CGAffineTransform(scaleX: 1, y: -1)
-
         messageLabel.text = message.text
         
 


### PR DESCRIPTION
## Summary
- remove inverted table view
- update data source animation
- append messages in natural order
- clean up cell transformation

## Testing
- `swift build` *(fails: manifest property 'defaultLocalization' not set)*

------
https://chatgpt.com/codex/tasks/task_e_685d0bf7e058832b8610e64348d5257c