### PR TITLE
Fix layout issue with chat messages

### DIFF
--- a/chatGPT/Presentation/Scene/MainViewController.swift
+++ b/chatGPT/Presentation/Scene/MainViewController.swift
@@ -108,6 +108,8 @@ final class MainViewController: UIViewController {
         tableView.separatorStyle = .none
         tableView.register(ChatMessageCell.self, forCellReuseIdentifier: "ChatMessageCell")
         tableView.keyboardDismissMode = .interactive
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.estimatedRowHeight = 60
         return tableView
     }()
     


### PR DESCRIPTION
## Summary
- fix automatic cell height for message list

## Testing
- `swift test --enable-test-discovery` *(fails: manifest property 'defaultLocalization' not set)*

------
https://chatgpt.com/codex/tasks/task_e_685d153aae84832b881d9502085640c4