### PR TITLE
Update streaming row reload logic

### DIFF
--- a/chatGPT/Presentation/Scene/MainViewController.swift
+++ b/chatGPT/Presentation/Scene/MainViewController.swift
@@ -228,6 +228,8 @@ final class MainViewController: UIViewController {
                     cell.update(text: message.text)
                     self.tableView.beginUpdates()
                     self.tableView.endUpdates()
+                } else {
+                    self.tableView.reloadRows(at: [indexPath], with: .none)
                 }
             })
             .disposed(by: disposeBag)


### PR DESCRIPTION
## Summary
- reload table row when cell is offscreen during streaming

## Testing
- `swift test` *(fails: manifest property `defaultLocalization` not set)*

------
https://chatgpt.com/codex/tasks/task_e_685d187b2ce0832bae4d3173237d11ac