### PR TITLE
Add vertical constraints to StreamToggleCell

### DIFF
--- a/chatGPT/Presentation/Scene/Cells/StreamToggleCell.swift
+++ b/chatGPT/Presentation/Scene/Cells/StreamToggleCell.swift
@@ -28,7 +28,7 @@ final class StreamToggleCell: UITableViewCell {
 
         titleLabel.snp.makeConstraints { make in
             make.leading.equalToSuperview().inset(16)
-            make.centerY.equalToSuperview()
+            make.top.bottom.equalToSuperview().inset(8)
         }
 
         toggleSwitch.snp.makeConstraints { make in


### PR DESCRIPTION
## Summary
- update layout() to pin title label vertically

## Testing
- `swift test` *(fails: manifest property 'defaultLocalization' not set)*

------
https://chatgpt.com/codex/tasks/task_e_685d187a4ad8832b89020ee1ae3c2927