### PR TITLE
Add default localization

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "chatGPT",
+    defaultLocalization: "ko",
     targets: [
         .executableTarget(
             name: "chatGPT",


### PR DESCRIPTION
## Summary
- add Korean localization setting in Package manifest

## Testing
- `swift test --enable-test-discovery` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_685d1878c1d0832b99f71e4cb019e4a8