### PR TITLE
Fix scroll on conversation switch

### DIFF
--- a/chatGPT/Presentation/Scene/MainViewController.swift
+++ b/chatGPT/Presentation/Scene/MainViewController.swift
@@ -238,6 +238,7 @@ final class MainViewController: UIViewController {
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] in
                 self?.animateDifferences = false
+                self?.lastMessageCount = 0
             })
             .disposed(by: disposeBag)
         
@@ -321,7 +322,9 @@ final class MainViewController: UIViewController {
             }
         }
 
-        animateDifferences = true
+        if !messages.isEmpty {
+            animateDifferences = true
+        }
     }
     
     private func loadUserImage() {


### PR DESCRIPTION
## Summary
- disable animations until messages appear
- reset message counter on chat change

## Testing
- `swift test` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_685d1d534074832b997ba43d786d86c4