### PR TITLE
Fix conversation view refresh

### DIFF
--- a/chatGPT/Presentation/Scene/MainViewController.swift
+++ b/chatGPT/Presentation/Scene/MainViewController.swift
@@ -211,7 +211,7 @@ final class MainViewController: UIViewController {
             .asDriver(onErrorJustReturn: [])
             .drive(onNext: { [weak self] messages in
                 guard let self else { return }
-                if messages.count != self.lastMessageCount {
+                if messages.count != self.lastMessageCount || !self.animateDifferences {
                     self.applySnapshot(messages)
                     self.lastMessageCount = messages.count
                 }


### PR DESCRIPTION
## Summary
- update chat message binding logic to force snapshot refresh when conversation changes

## Testing
- `swift test` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_685d27610e2c832b922d5b77cb4ebc76