### PR TITLE
Optimize streaming cell updates

### DIFF
--- a/chatGPT/Presentation/Scene/Cells/ChatMessageCell.swift
+++ b/chatGPT/Presentation/Scene/Cells/ChatMessageCell.swift
@@ -10,6 +10,8 @@ import SnapKit
 
 final class ChatMessageCell: UITableViewCell {
 
+    private var lastHeight: CGFloat = 0
+
     private let bubbleView = UIView()
     private let messageLabel: UILabel = {
         let label = UILabel()
@@ -54,7 +56,7 @@ final class ChatMessageCell: UITableViewCell {
     func configure(with message: ChatViewModel.ChatMessage) {
 
         messageLabel.text = message.text
-        
+
 
         switch message.type {
         case .user:
@@ -99,10 +101,17 @@ final class ChatMessageCell: UITableViewCell {
             }
         }
 
+        layoutIfNeeded()
+        lastHeight = messageLabel.bounds.height
+
     }
 
-    func update(text: String) {
+    @discardableResult
+    func update(text: String) -> Bool {
         messageLabel.text = text
         layoutIfNeeded()
+        let newHeight = messageLabel.bounds.height
+        defer { lastHeight = newHeight }
+        return newHeight != lastHeight
     }
 }

--- a/chatGPT/Presentation/Scene/MainViewController.swift
+++ b/chatGPT/Presentation/Scene/MainViewController.swift
@@ -231,14 +231,13 @@ final class MainViewController: UIViewController {
                 
                 // 셀을 찾아 직접 업데이트
                 if let cell = self.tableView.cellForRow(at: indexPath) as? ChatMessageCell {
-                    cell.update(text: message.text)
-
-                    // 셀의 높이가 변할 수 있으므로 레이아웃 갱신
-                    UIView.performWithoutAnimation {
-                        self.tableView.beginUpdates()
-                        self.tableView.endUpdates()
+                    let heightChanged = cell.update(text: message.text)
+                    if heightChanged {
+                        UIView.performWithoutAnimation {
+                            self.tableView.beginUpdates()
+                            self.tableView.endUpdates()
+                        }
                     }
-
                 }
             })
             .disposed(by: disposeBag)


### PR DESCRIPTION
## Summary
- cache height inside `ChatMessageCell`
- update row layout only when height changes during streaming

## Testing
- `swift test` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_685e3220afa8832bbbf2eedcbdad6ffb