### PR TITLE
Update menu cells with default labels

### DIFF
--- a/chatGPT/Presentation/Scene/Cells/ModelSelectCell.swift
+++ b/chatGPT/Presentation/Scene/Cells/ModelSelectCell.swift
@@ -2,7 +2,6 @@ import UIKit
 import SnapKit
 
 final class ModelSelectCell: UITableViewCell {
-    private let titleLabel = UILabel()
     private let valueButton: UIButton = {
         let button = UIButton(type: .system)
         button.setTitleColor(.label, for: .normal)
@@ -20,16 +19,11 @@ final class ModelSelectCell: UITableViewCell {
     }
 
     private func layout() {
-        [titleLabel, valueButton].forEach(contentView.addSubview)
+        contentView.addSubview(valueButton)
         selectionStyle = .default
 
-        titleLabel.font = .systemFont(ofSize: 16)
+        textLabel?.font = .systemFont(ofSize: 16)
         valueButton.titleLabel?.font = .systemFont(ofSize: 16)
-
-        titleLabel.snp.makeConstraints { make in
-            make.leading.equalToSuperview().inset(16)
-            make.centerY.equalToSuperview()
-        }
 
         valueButton.snp.makeConstraints { make in
             // 32 is roughly the width of disclosure indicator area
@@ -39,7 +33,7 @@ final class ModelSelectCell: UITableViewCell {
     }
 
     func configure(title: String, modelName: String, loading: Bool, menu: UIMenu?) {
-        titleLabel.text = title
+        textLabel?.text = title
         valueButton.setTitle(loading ? "모델 불러오는 중..." : modelName, for: .normal)
         valueButton.isEnabled = !loading
         valueButton.menu = menu

--- a/chatGPT/Presentation/Scene/Cells/StreamToggleCell.swift
+++ b/chatGPT/Presentation/Scene/Cells/StreamToggleCell.swift
@@ -4,7 +4,6 @@ import RxSwift
 import RxCocoa
 
 final class StreamToggleCell: UITableViewCell {
-    private let titleLabel = UILabel()
     private let toggleSwitch = UISwitch()
     private let disposeBag = DisposeBag()
 
@@ -22,15 +21,9 @@ final class StreamToggleCell: UITableViewCell {
 
     private func layout() {
         selectionStyle = .none
-        titleLabel.text = "스트림"
+        textLabel?.text = "스트림"
 
-        [titleLabel, toggleSwitch].forEach(contentView.addSubview)
-
-        titleLabel.snp.makeConstraints { make in
-            make.leading.equalToSuperview().inset(16)
-            make.top.bottom.equalToSuperview().inset(8)
-        }
-
+        contentView.addSubview(toggleSwitch)
         toggleSwitch.snp.makeConstraints { make in
             make.trailing.equalToSuperview().inset(16)
             make.centerY.equalToSuperview()


### PR DESCRIPTION
## Summary
- swap custom labels for built-in `textLabel`
- keep button and switch positions using SnapKit

## Testing
- `swift test` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_685e8e132784832ba9df2b9c6f93667d