### PR TITLE
Add markdown support with Down

### DIFF
--- a/chatGPT/Data/DownMarkdownRepository.swift
+++ b/chatGPT/Data/DownMarkdownRepository.swift
@@ -1,0 +1,11 @@
+import UIKit
+import Down
+
+final class DownMarkdownRepository: MarkdownRepository {
+    func parse(_ markdown: String) -> NSAttributedString {
+        if let attributed = try? Down(markdownString: markdown).toAttributedString() {
+            return attributed
+        }
+        return NSAttributedString(string: markdown)
+    }
+}

--- a/chatGPT/Domain/Repository/MarkdownRepository.swift
+++ b/chatGPT/Domain/Repository/MarkdownRepository.swift
@@ -1,0 +1,5 @@
+import UIKit
+
+protocol MarkdownRepository {
+    func parse(_ markdown: String) -> NSAttributedString
+}

--- a/chatGPT/Domain/UseCase/ParseMarkdownUseCase.swift
+++ b/chatGPT/Domain/UseCase/ParseMarkdownUseCase.swift
@@ -1,0 +1,13 @@
+import UIKit
+
+final class ParseMarkdownUseCase {
+    private let repository: MarkdownRepository
+
+    init(repository: MarkdownRepository) {
+        self.repository = repository
+    }
+
+    func execute(markdown: String) -> NSAttributedString {
+        repository.parse(markdown)
+    }
+}

--- a/chatGPT/Presentation/Coordinator/AppCoordinator.swift
+++ b/chatGPT/Presentation/Coordinator/AppCoordinator.swift
@@ -82,6 +82,8 @@ final class AppCoordinator {
             getCurrentUserUseCase: getCurrentUserUseCase
         )
         let observeAuthStateUseCase = ObserveAuthStateUseCase(repository: authRepository)
+        let markdownRepository = DownMarkdownRepository()
+        let parseMarkdownUseCase = ParseMarkdownUseCase(repository: markdownRepository)
 
         let vc = MainViewController(
             fetchModelsUseCase: fetchModelsUseCase,
@@ -94,7 +96,8 @@ final class AppCoordinator {
             observeConversationsUseCase: observeConversationsUseCase,
             signOutUseCase: signOutUseCase,
             loadUserImageUseCase: loadUserImageUseCase,
-            observeAuthStateUseCase: observeAuthStateUseCase
+            observeAuthStateUseCase: observeAuthStateUseCase,
+            parseMarkdownUseCase: parseMarkdownUseCase
         )
         
         let nav = UINavigationController(rootViewController: vc)

--- a/chatGPT/Presentation/Scene/Cells/ChatMessageCell.swift
+++ b/chatGPT/Presentation/Scene/Cells/ChatMessageCell.swift
@@ -55,9 +55,17 @@ final class ChatMessageCell: UITableViewCell {
         }
     }
 
-    func configure(with message: ChatViewModel.ChatMessage) {
+    func configure(with message: ChatViewModel.ChatMessage,
+                   parser: ParseMarkdownUseCase) {
 
-        messageView.attributedText = message.text.markdownAttributed(font: messageView.font ?? .systemFont(ofSize: 16), textColor: messageView.textColor ?? .label)
+        let attributed = parser.execute(markdown: message.text)
+        let mutable = NSMutableAttributedString(attributedString: attributed)
+        let range = NSRange(location: 0, length: mutable.length)
+        mutable.addAttributes([
+            .font: messageView.font ?? .systemFont(ofSize: 16),
+            .foregroundColor: messageView.textColor ?? .label
+        ], range: range)
+        messageView.attributedText = mutable
 
 
         switch message.type {
@@ -109,8 +117,15 @@ final class ChatMessageCell: UITableViewCell {
     }
 
     @discardableResult
-    func update(text: String) -> Bool {
-        messageView.attributedText = text.markdownAttributed(font: messageView.font ?? .systemFont(ofSize: 16), textColor: messageView.textColor ?? .label)
+    func update(text: String, parser: ParseMarkdownUseCase) -> Bool {
+        let attributed = parser.execute(markdown: text)
+        let mutable = NSMutableAttributedString(attributedString: attributed)
+        let range = NSRange(location: 0, length: mutable.length)
+        mutable.addAttributes([
+            .font: messageView.font ?? .systemFont(ofSize: 16),
+            .foregroundColor: messageView.textColor ?? .label
+        ], range: range)
+        messageView.attributedText = mutable
         layoutIfNeeded()
         let newHeight = messageView.contentSize.height
         defer { lastHeight = newHeight }

--- a/chatGPT/Presentation/Scene/MainViewController.swift
+++ b/chatGPT/Presentation/Scene/MainViewController.swift
@@ -21,6 +21,7 @@ final class MainViewController: UIViewController {
     private let observeConversationsUseCase: ObserveConversationsUseCase
     private let loadUserImageUseCase: LoadUserProfileImageUseCase
     private let observeAuthStateUseCase: ObserveAuthStateUseCase
+    private let parseMarkdownUseCase: ParseMarkdownUseCase
 
     private let disposeBag = DisposeBag()
 
@@ -126,10 +127,11 @@ final class MainViewController: UIViewController {
          appendMessageUseCase: AppendMessageUseCase,
          fetchConversationMessagesUseCase: FetchConversationMessagesUseCase,
          contextRepository: ChatContextRepository,
-         observeConversationsUseCase: ObserveConversationsUseCase,
-         signOutUseCase: SignOutUseCase,
-         loadUserImageUseCase: LoadUserProfileImageUseCase,
-         observeAuthStateUseCase: ObserveAuthStateUseCase) {
+        observeConversationsUseCase: ObserveConversationsUseCase,
+        signOutUseCase: SignOutUseCase,
+        loadUserImageUseCase: LoadUserProfileImageUseCase,
+         observeAuthStateUseCase: ObserveAuthStateUseCase,
+         parseMarkdownUseCase: ParseMarkdownUseCase) {
         self.fetchModelsUseCase = fetchModelsUseCase
         self.chatViewModel = ChatViewModel(sendMessageUseCase: sendChatMessageUseCase,
                                            summarizeUseCase: summarizeUseCase,
@@ -141,6 +143,7 @@ final class MainViewController: UIViewController {
         self.observeConversationsUseCase = observeConversationsUseCase
         self.loadUserImageUseCase = loadUserImageUseCase
         self.observeAuthStateUseCase = observeAuthStateUseCase
+        self.parseMarkdownUseCase = parseMarkdownUseCase
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -223,7 +226,7 @@ final class MainViewController: UIViewController {
                 
                 // 셀을 찾아 직접 업데이트
                 if let cell = self.tableView.cellForRow(at: indexPath) as? ChatMessageCell {
-                    let heightChanged = cell.update(text: message.text)
+                    let heightChanged = cell.update(text: message.text, parser: self.parseMarkdownUseCase)
                     if heightChanged {
                         UIView.performWithoutAnimation {
                             self.tableView.beginUpdates()
@@ -271,7 +274,7 @@ final class MainViewController: UIViewController {
     private func createDataSource() -> UITableViewDiffableDataSource<Int, ChatViewModel.ChatMessage> {
         let dataSource = UITableViewDiffableDataSource<Int, ChatViewModel.ChatMessage>(tableView: tableView) { tableView, indexPath, message in
             let cell = tableView.dequeueReusableCell(withIdentifier: "ChatMessageCell", for: indexPath) as! ChatMessageCell
-            cell.configure(with: message)
+            cell.configure(with: message, parser: self.parseMarkdownUseCase)
             return cell
         }
         dataSource.defaultRowAnimation = .none


### PR DESCRIPTION
## Summary
- integrate DownMarkdownRepository using Down package
- add ParseMarkdownUseCase and repository protocol
- convert messages to markdown in MainViewController and ChatMessageCell
- wire new use case from AppCoordinator

## Testing
- `swift build` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_686286b3ba64832bacdceb0a0f72fe08