### PR TITLE
Improve markdown parsing

### DIFF
--- a/chatGPT/Data/DownMarkdownRepository.swift
+++ b/chatGPT/Data/DownMarkdownRepository.swift
@@ -3,9 +3,37 @@ import Down
 
 final class DownMarkdownRepository: MarkdownRepository {
     func parse(_ markdown: String) -> NSAttributedString {
-        if let attributed = try? Down(markdownString: markdown).toAttributedString() {
+        // 마크다운을 HTML로 변환 후 스타일을 입혀 NSAttributedString으로 반환
+        guard let html = try? Down(markdownString: markdown).toHTML() else {
+            return NSAttributedString(string: markdown)
+        }
+
+        let styledHTML = """
+        <html>
+        <head>
+        <style>
+        body { font-family: -apple-system; font-size: 16px; }
+        pre { background-color: #F5F5F5; padding: 8px; border-radius: 4px; }
+        code { font-family: Menlo; }
+        </style>
+        </head>
+        <body>\(html)</body>
+        </html>
+        """
+
+        guard let data = styledHTML.data(using: .utf8) else {
+            return NSAttributedString(string: markdown)
+        }
+
+        let options: [NSAttributedString.DocumentReadingOptionKey: Any] = [
+            .documentType: NSAttributedString.DocumentType.html,
+            .characterEncoding: String.Encoding.utf8.rawValue
+        ]
+
+        if let attributed = try? NSAttributedString(data: data, options: options, documentAttributes: nil) {
             return attributed
         }
+
         return NSAttributedString(string: markdown)
     }
 }

--- a/chatGPT/Presentation/Scene/Cells/ChatMessageCell.swift
+++ b/chatGPT/Presentation/Scene/Cells/ChatMessageCell.swift
@@ -58,14 +58,13 @@ final class ChatMessageCell: UITableViewCell {
     func configure(with message: ChatViewModel.ChatMessage,
                    parser: ParseMarkdownUseCase) {
 
-        let attributed = parser.execute(markdown: message.text)
-        let mutable = NSMutableAttributedString(attributedString: attributed)
-        let range = NSRange(location: 0, length: mutable.length)
-        mutable.addAttributes([
-            .font: messageView.font ?? .systemFont(ofSize: 16),
-            .foregroundColor: messageView.textColor ?? .label
-        ], range: range)
-        messageView.attributedText = mutable
+        switch message.type {
+        case .assistant:
+            messageView.attributedText = parser.execute(markdown: message.text)
+        default:
+            messageView.text = message.text
+            messageView.font = .systemFont(ofSize: 16)
+        }
 
 
         switch message.type {
@@ -118,14 +117,7 @@ final class ChatMessageCell: UITableViewCell {
 
     @discardableResult
     func update(text: String, parser: ParseMarkdownUseCase) -> Bool {
-        let attributed = parser.execute(markdown: text)
-        let mutable = NSMutableAttributedString(attributedString: attributed)
-        let range = NSRange(location: 0, length: mutable.length)
-        mutable.addAttributes([
-            .font: messageView.font ?? .systemFont(ofSize: 16),
-            .foregroundColor: messageView.textColor ?? .label
-        ], range: range)
-        messageView.attributedText = mutable
+        messageView.attributedText = parser.execute(markdown: text)
         layoutIfNeeded()
         let newHeight = messageView.contentSize.height
         defer { lastHeight = newHeight }


### PR DESCRIPTION
## Summary
- enhance `DownMarkdownRepository` to render HTML with basic styles
- avoid overriding fonts in `ChatMessageCell`
- keep user messages plain without markdown parsing

## Testing
- `swift test` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_68628955f28c832bbaf9ef3e716a7b92