### PR TITLE
Enable horizontal scrolling for code blocks

### DIFF
--- a/chatGPT/Components/CodeBlockView.swift
+++ b/chatGPT/Components/CodeBlockView.swift
@@ -17,11 +17,19 @@ final class CodeBlockView: UIView {
         return view
     }()
 
+    private let contentView: UIView = {
+        let view = UIView()
+        return view
+    }()
+
     private let codeLabel: UILabel = {
         let label = UILabel()
         label.numberOfLines = 0
+        label.lineBreakMode = .byClipping
         label.font = UIFont.monospacedSystemFont(ofSize: 14, weight: .regular)
         label.textColor = ThemeColor.label1
+        label.setContentHuggingPriority(.required, for: .horizontal)
+        label.setContentCompressionResistancePriority(.required, for: .horizontal)
         return label
     }()
 
@@ -49,15 +57,22 @@ final class CodeBlockView: UIView {
 
         addSubview(scrollView)
         addSubview(copyButton)
-        scrollView.addSubview(codeLabel)
+        scrollView.addSubview(contentView)
+        contentView.addSubview(codeLabel)
 
         scrollView.snp.makeConstraints { make in
             make.edges.equalToSuperview().inset(12)
         }
 
+        contentView.snp.makeConstraints { make in
+            make.top.bottom.leading.equalToSuperview()
+            make.trailing.equalToSuperview().priority(.low)
+            make.width.greaterThanOrEqualToSuperview()
+            make.height.equalToSuperview()
+        }
+
         codeLabel.snp.makeConstraints { make in
             make.edges.equalToSuperview()
-            make.width.equalToSuperview()
         }
 
         copyButton.snp.makeConstraints { make in


### PR DESCRIPTION
## Summary
- update CodeBlockView to prevent vertical scroll and allow horizontal scroll

## Testing
- `swift test` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_6863b55d464c832b88522667769f7484