### PR TITLE
Optimize streaming update

### DIFF
--- a/chatGPT/Presentation/Scene/MainViewController.swift
+++ b/chatGPT/Presentation/Scene/MainViewController.swift
@@ -229,7 +229,8 @@ final class MainViewController: UIViewController {
                     let heightChanged = cell.update(text: message.text, parser: self.parseMarkdownUseCase)
                     if heightChanged {
                         UIView.performWithoutAnimation {
-                            self.tableView.performBatchUpdates(nil, completion: nil)
+                            self.tableView.beginUpdates()
+                            self.tableView.endUpdates()
                         }
                     }
                 }
@@ -285,7 +286,7 @@ final class MainViewController: UIViewController {
         snapshot.appendSections([0])
         snapshot.appendItems(messages)
         UIView.performWithoutAnimation {
-            dataSource.apply(snapshot, animatingDifferences: false)
+            dataSource.applySnapshotUsingReloadData(snapshot)
             if !messages.isEmpty {
                 tableView.layoutIfNeeded()
             }


### PR DESCRIPTION
## Summary
- skip snapshot updates while streaming messages
- update list after stream completion
- use `applySnapshotUsingReloadData` for consistency
- refresh row heights with `beginUpdates`/`endUpdates`

## Testing
- `swift test` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_6863b6cbb590832bbed326009b6a0d27