### PR TITLE
Fix invisible text in chat cells

### DIFF
--- a/chatGPT/Data/DownMarkdownRepository.swift
+++ b/chatGPT/Data/DownMarkdownRepository.swift
@@ -32,6 +32,9 @@ final class DownMarkdownRepository: MarkdownRepository {
 
         let result = NSMutableAttributedString()
         parts.forEach { result.append($0) }
+        let range = NSRange(location: 0, length: result.length)
+        result.removeAttribute(.foregroundColor, range: range)
+        result.addAttribute(.foregroundColor, value: UIColor.label, range: range)
         return result
     }
 

--- a/chatGPT/Presentation/Scene/Cells/ChatMessageCell.swift
+++ b/chatGPT/Presentation/Scene/Cells/ChatMessageCell.swift
@@ -22,6 +22,7 @@ final class ChatMessageCell: UITableViewCell {
         view.textContainerInset = .zero
         view.textContainer.lineFragmentPadding = 0
         view.dataDetectorTypes = [.link]
+        view.textColor = .label
         return view
     }()
     private let stackView: UIStackView = {
@@ -78,6 +79,7 @@ final class ChatMessageCell: UITableViewCell {
         view.textContainerInset = .zero
         view.textContainer.lineFragmentPadding = 0
         view.dataDetectorTypes = [.link]
+        view.textColor = .label
         return view
     }
 


### PR DESCRIPTION
## Summary
- ensure parsed markdown uses dynamic label color
- set default text view color to label

## Testing
- `swift test` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_6863ba8b84a8832b886aae12690fecae