### PR TITLE
Add horizontal rule rendering

### DIFF
--- a/chatGPT.xcodeproj/project.pbxproj
+++ b/chatGPT.xcodeproj/project.pbxproj
@@ -57,8 +57,10 @@
 		F19F74312DFC57E6007AB4C1 /* ChatComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F19F74302DFC57E6007AB4C1 /* ChatComposerView.swift */; };
                 F1B7F7602DF9DC68002D12BB /* LinkLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1B7F75F2DF9DC68002D12BB /* LinkLabel.swift */; };
                 8A5B3792D339FC9598AD2D81 /* CodeBlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 717BADADF1E39907F7A046E9 /* CodeBlockView.swift */; };
-                B053CFA5A8F732BF66D3DCA4 /* CodeBlockAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E3AE2342A568CE6890C03F0 /* CodeBlockAttachment.swift */; };
-                06E9380ABC93A109EEA9D9DD /* UITextView+Attachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7745C5EDAA99DD0CAA4DF5 /* UITextView+Attachment.swift */; };
+               B053CFA5A8F732BF66D3DCA4 /* CodeBlockAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E3AE2342A568CE6890C03F0 /* CodeBlockAttachment.swift */; };
+               F12111112F0A000100D00000 /* HorizontalRuleAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12111102F0A000100D00000 /* HorizontalRuleAttachment.swift */; };
+               F12111132F0A000100D00000 /* HorizontalRuleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12111122F0A000100D00000 /* HorizontalRuleView.swift */; };
+               06E9380ABC93A109EEA9D9DD /* UITextView+Attachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7745C5EDAA99DD0CAA4DF5 /* UITextView+Attachment.swift */; };
                 F1B7F7632DF9E541002D12BB /* KeyboardAdjustable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1B7F7622DF9E541002D12BB /* KeyboardAdjustable.swift */; };
 		F1C3BF152E0EBF8A000E4A99 /* ModelSelectCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C3BF142E0EBF8A000E4A99 /* ModelSelectCell.swift */; };
 		F1C897122E044087000A0C3D /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = F1C897112E044087000A0C3D /* GoogleSignIn */; };
@@ -189,8 +191,10 @@
 		eef3624df55348a684cdc5fd /* LoadUserProfileImageUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadUserProfileImageUseCase.swift; sourceTree = "<group>"; };
                 f495b15056fc494682c60df5 /* SendChatWithContextUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendChatWithContextUseCase.swift; sourceTree = "<group>"; };
                 717BADADF1E39907F7A046E9 /* CodeBlockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeBlockView.swift; sourceTree = "<group>"; };
-                7E3AE2342A568CE6890C03F0 /* CodeBlockAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeBlockAttachment.swift; sourceTree = "<group>"; };
-                6A7745C5EDAA99DD0CAA4DF5 /* UITextView+Attachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextView+Attachment.swift"; sourceTree = "<group>"; };
+               7E3AE2342A568CE6890C03F0 /* CodeBlockAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeBlockAttachment.swift; sourceTree = "<group>"; };
+               F12111102F0A000100D00000 /* HorizontalRuleAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalRuleAttachment.swift; sourceTree = "<group>"; };
+               F12111122F0A000100D00000 /* HorizontalRuleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalRuleView.swift; sourceTree = "<group>"; };
+               6A7745C5EDAA99DD0CAA4DF5 /* UITextView+Attachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextView+Attachment.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -458,11 +462,13 @@
                                 F1DF3B242DF9B5CD00D8445A /* BorderedTextField.swift */,
                                 F1DF3B262DF9B61400D8445A /* BorderedTextView.swift */,
                                 F1B7F75F2DF9DC68002D12BB /* LinkLabel.swift */,
-                                F19F74302DFC57E6007AB4C1 /* ChatComposerView.swift */,
-                                F1EF04EC2E044CDE005D2CF9 /* GoogleLoginButton.swift */,
-                                717BADADF1E39907F7A046E9 /* CodeBlockView.swift */,
-                                7E3AE2342A568CE6890C03F0 /* CodeBlockAttachment.swift */,
-                        );
+                               F19F74302DFC57E6007AB4C1 /* ChatComposerView.swift */,
+                               F1EF04EC2E044CDE005D2CF9 /* GoogleLoginButton.swift */,
+                               717BADADF1E39907F7A046E9 /* CodeBlockView.swift */,
+                               7E3AE2342A568CE6890C03F0 /* CodeBlockAttachment.swift */,
+                               F12111122F0A000100D00000 /* HorizontalRuleView.swift */,
+                               F12111102F0A000100D00000 /* HorizontalRuleAttachment.swift */,
+                       );
                         path = Components;
                         sourceTree = "<group>";
                 };
@@ -655,9 +661,11 @@
 				F19F74312DFC57E6007AB4C1 /* ChatComposerView.swift in Sources */,
 				F1051DF32E004E17008D5D80 /* OpenAIResponse.swift in Sources */,
                                F1B7F7602DF9DC68002D12BB /* LinkLabel.swift in Sources */,
-                                8A5B3792D339FC9598AD2D81 /* CodeBlockView.swift in Sources */,
-                                B053CFA5A8F732BF66D3DCA4 /* CodeBlockAttachment.swift in Sources */,
-                                06E9380ABC93A109EEA9D9DD /* UITextView+Attachment.swift in Sources */,
+                               8A5B3792D339FC9598AD2D81 /* CodeBlockView.swift in Sources */,
+                               B053CFA5A8F732BF66D3DCA4 /* CodeBlockAttachment.swift in Sources */,
+                               F12111112F0A000100D00000 /* HorizontalRuleAttachment.swift in Sources */,
+                               F12111132F0A000100D00000 /* HorizontalRuleView.swift in Sources */,
+                               06E9380ABC93A109EEA9D9DD /* UITextView+Attachment.swift in Sources */,
                                ED3EEADB42E0AF92425F1398 /* SwiftMarkdownRepository.swift in Sources */,
 				F1DF3B032DF9AF7B00D8445A /* KeychainAPIKeyRepository.swift in Sources */,
 				F1C3BF152E0EBF8A000E4A99 /* ModelSelectCell.swift in Sources */,

--- a/chatGPT/Components/HorizontalRuleAttachment.swift
+++ b/chatGPT/Components/HorizontalRuleAttachment.swift
@@ -1,0 +1,18 @@
+import UIKit
+
+final class HorizontalRuleAttachment: NSTextAttachment {
+    let view: HorizontalRuleView
+
+    override init(data: Data? = nil, ofType uti: String? = nil) {
+        self.view = HorizontalRuleView()
+        super.init(data: data, ofType: uti)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func attachmentBounds(for textContainer: NSTextContainer?, proposedLineFragment lineFrag: CGRect, glyphPosition position: CGPoint, characterIndex charIndex: Int) -> CGRect {
+        CGRect(x: 0, y: 0, width: lineFrag.width, height: 1 / UIScreen.main.scale)
+    }
+}

--- a/chatGPT/Components/HorizontalRuleView.swift
+++ b/chatGPT/Components/HorizontalRuleView.swift
@@ -1,0 +1,13 @@
+import UIKit
+
+final class HorizontalRuleView: UIView {
+    init() {
+        super.init(frame: .zero)
+        backgroundColor = ThemeColor.label2
+        autoresizingMask = [.flexibleWidth]
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/chatGPT/Data/SwiftMarkdownRepository.swift
+++ b/chatGPT/Data/SwiftMarkdownRepository.swift
@@ -38,18 +38,35 @@ final class SwiftMarkdownRepository: MarkdownRepository {
     }
 
     private func attributed(from markdown: String) -> NSAttributedString {
-        var options = AttributedString.MarkdownParsingOptions()
-        options.interpretedSyntax = .inlineOnlyPreservingWhitespace
-        if let attr = try? AttributedString(markdown: markdown, options: options) {
-            let ns = NSMutableAttributedString(attr)
-            let range = NSRange(location: 0, length: ns.length)
-            ns.addAttribute(.font, value: UIFont.systemFont(ofSize: 16), range: range)
-            ns.addAttribute(.foregroundColor, value: UIColor.label, range: range)
-            return ns
+        let lines = markdown.split(separator: "\n", omittingEmptySubsequences: false)
+        let result = NSMutableAttributedString()
+
+        for (index, lineSub) in lines.enumerated() {
+            let line = String(lineSub)
+            if line.trimmingCharacters(in: .whitespaces) == "---" {
+                let attachment = HorizontalRuleAttachment()
+                result.append(NSAttributedString(attachment: attachment))
+            } else {
+                var options = AttributedString.MarkdownParsingOptions()
+                options.interpretedSyntax = .inlineOnlyPreservingWhitespace
+                if let attr = try? AttributedString(markdown: line, options: options) {
+                    let ns = NSMutableAttributedString(attr)
+                    let range = NSRange(location: 0, length: ns.length)
+                    ns.addAttribute(.font, value: UIFont.systemFont(ofSize: 16), range: range)
+                    ns.addAttribute(.foregroundColor, value: UIColor.label, range: range)
+                    result.append(ns)
+                } else {
+                    result.append(NSAttributedString(string: line, attributes: [
+                        .font: UIFont.systemFont(ofSize: 16),
+                        .foregroundColor: UIColor.label
+                    ]))
+                }
+            }
+            if index < lines.count - 1 {
+                result.append(NSAttributedString(string: "\n"))
+            }
         }
-        return NSAttributedString(string: markdown, attributes: [
-            .font: UIFont.systemFont(ofSize: 16),
-            .foregroundColor: UIColor.label
-        ])
+
+        return result
     }
 }

--- a/chatGPT/Presentation/Helpers/UITextView+Attachment.swift
+++ b/chatGPT/Presentation/Helpers/UITextView+Attachment.swift
@@ -3,17 +3,25 @@ import UIKit
 extension UITextView {
     func addAttachmentViews() {
         subviews.forEach { view in
-            if view is CodeBlockView { view.removeFromSuperview() }
+            if view is CodeBlockView || view is HorizontalRuleView {
+                view.removeFromSuperview()
+            }
         }
 
         guard let attributed = attributedText else { return }
         let fullRange = NSRange(location: 0, length: attributed.length)
         attributed.enumerateAttribute(.attachment, in: fullRange) { value, range, _ in
-            guard let attachment = value as? CodeBlockAttachment else { return }
-            let rect = self.boundingRect(forCharacterRange: range)
-            guard !rect.isNull, !rect.isInfinite, !rect.isEmpty else { return }
-            attachment.view.frame = rect
-            addSubview(attachment.view)
+            if let attachment = value as? CodeBlockAttachment {
+                let rect = self.boundingRect(forCharacterRange: range)
+                guard !rect.isNull, !rect.isInfinite, !rect.isEmpty else { return }
+                attachment.view.frame = rect
+                addSubview(attachment.view)
+            } else if let attachment = value as? HorizontalRuleAttachment {
+                let rect = self.boundingRect(forCharacterRange: range)
+                guard !rect.isNull, !rect.isInfinite, !rect.isEmpty else { return }
+                attachment.view.frame = rect
+                addSubview(attachment.view)
+            }
         }
     }
 

--- a/chatGPT/Presentation/Scene/Cells/ChatMessageCell.swift
+++ b/chatGPT/Presentation/Scene/Cells/ChatMessageCell.swift
@@ -90,6 +90,8 @@ final class ChatMessageCell: UITableViewCell {
         attributed.enumerateAttributes(in: fullRange) { attrs, range, _ in
             if let attachment = attrs[.attachment] as? CodeBlockAttachment {
                 stackView.addArrangedSubview(attachment.view)
+            } else if let attachment = attrs[.attachment] as? HorizontalRuleAttachment {
+                stackView.addArrangedSubview(attachment.view)
             } else {
                 let textView = makeTextView()
                 textView.attributedText = attributed.attributedSubstring(from: range)


### PR DESCRIPTION
## Summary
- show horizontal rule when message contains `---`
- support new attachment view for horizontal rules
- parse markdown lines to detect `---` and convert to a horizontal line
- update helper and project file

## Testing
- `swift test` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_6863c46eaf04832bb47ca9f41417dedf