### PR TITLE
Fix inline code styling

### DIFF
--- a/chatGPT/Components/InlineCodeView.swift
+++ b/chatGPT/Components/InlineCodeView.swift
@@ -5,13 +5,16 @@ final class InlineCodeView: UILabel {
 
     init(code: String) {
         super.init(frame: .zero)
-        text = code
-        font = UIFont.monospacedSystemFont(ofSize: 14, weight: .regular)
-        textColor = ThemeColor.inlineCodeForeground
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: UIFont.monospacedSystemFont(ofSize: 14, weight: .regular),
+            .foregroundColor: ThemeColor.inlineCodeForeground
+        ]
+        attributedText = NSAttributedString(string: code, attributes: attributes)
         backgroundColor = ThemeColor.inlineCodeBackground
         layer.cornerRadius = 4
         layer.masksToBounds = true
         numberOfLines = 1
+        isOpaque = false
     }
 
     required init?(coder: NSCoder) {


### PR DESCRIPTION
## Summary
- update InlineCodeView init to apply requested colors consistently

## Testing
- `swift test --enable-test-discovery` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_6863cf9e4724832ba29d3350d2d2c2dc