### PR TITLE
Add conversation edit and delete actions

### DIFF
--- a/chatGPT.xcodeproj/project.pbxproj
+++ b/chatGPT.xcodeproj/project.pbxproj
@@ -97,7 +97,9 @@
 		c076797f219e4afdb2928170 /* SummarizeMessagesUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = ee987c883dab481cb2765061 /* SummarizeMessagesUseCase.swift */; };
 		ccfa5907f1434e87b23a8d58 /* SendChatWithContextUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = f495b15056fc494682c60df5 /* SendChatWithContextUseCase.swift */; };
 		d4ae3188874b4ea4a0abdef2 /* ObserveAuthStateUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9b8f82223d524f878b330338 /* ObserveAuthStateUseCase.swift */; };
-		edab8d1cb29b4a0d8fc109d2 /* ObserveConversationsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3e924cb7e10d40a1a28fc225 /* ObserveConversationsUseCase.swift */; };
+                edab8d1cb29b4a0d8fc109d2 /* ObserveConversationsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3e924cb7e10d40a1a28fc225 /* ObserveConversationsUseCase.swift */; };
+               FDF214A9E94D3F7E2DA0DEED /* UpdateConversationTitleUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1429C4B96A13E73C35752E4 /* UpdateConversationTitleUseCase.swift */; };
+               679ABD2960C6FE51CF51C1D7 /* DeleteConversationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64EB7DD9103C65295FB89E7C /* DeleteConversationUseCase.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -148,20 +150,22 @@
 		F12111102F0A000100D00000 /* HorizontalRuleAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalRuleAttachment.swift; sourceTree = "<group>"; };
 		F12111122F0A000100D00000 /* HorizontalRuleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalRuleView.swift; sourceTree = "<group>"; };
 		F122E5D12E0C034B006E81DD /* ConversationMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationMessage.swift; sourceTree = "<group>"; };
-		F122E5D32E0C0352006E81DD /* FetchConversationMessagesUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchConversationMessagesUseCase.swift; sourceTree = "<group>"; };
-		F122E5D52E0C0F01006E81DD /* String+Sanitize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Sanitize.swift"; sourceTree = "<group>"; };
-		F13EB5982E12BFED00171AFC /* MarkdownRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownRepository.swift; sourceTree = "<group>"; };
-		F13EB59A2E12BFF400171AFC /* ParseMarkdownUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseMarkdownUseCase.swift; sourceTree = "<group>"; };
+               F122E5D32E0C0352006E81DD /* FetchConversationMessagesUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchConversationMessagesUseCase.swift; sourceTree = "<group>"; };
+               F122E5D52E0C0F01006E81DD /* String+Sanitize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Sanitize.swift"; sourceTree = "<group>"; };
+               F13EB5982E12BFED00171AFC /* MarkdownRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownRepository.swift; sourceTree = "<group>"; };
+               F13EB59A2E12BFF400171AFC /* ParseMarkdownUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseMarkdownUseCase.swift; sourceTree = "<group>"; };
 		F1452D822E095F7D00795A9E /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		F1452D842E09741500795A9E /* AuthUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthUser.swift; sourceTree = "<group>"; };
 		F1452D862E09741F00795A9E /* GetCurrentUserUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetCurrentUserUseCase.swift; sourceTree = "<group>"; };
 		F1452D882E09796F00795A9E /* UIImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIImage.swift; sourceTree = "<group>"; };
 		F15BC4F52E0A955B00F25923 /* SaveConversationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveConversationUseCase.swift; sourceTree = "<group>"; };
 		F15BC4F72E0A957300F25923 /* ConversationRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationRepository.swift; sourceTree = "<group>"; };
-		F15BC4F92E0A959200F25923 /* FirestoreConversationRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestoreConversationRepository.swift; sourceTree = "<group>"; };
-		F15BC4FF2E0AC1A200F25923 /* ConversationSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationSummary.swift; sourceTree = "<group>"; };
-		F15BC5012E0AC1AB00F25923 /* FetchConversationsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchConversationsUseCase.swift; sourceTree = "<group>"; };
-		F16563C82DF9A30F001CDF3B /* chatGPT.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = chatGPT.app; sourceTree = BUILT_PRODUCTS_DIR; };
+               F15BC4F92E0A959200F25923 /* FirestoreConversationRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestoreConversationRepository.swift; sourceTree = "<group>"; };
+               F15BC4FF2E0AC1A200F25923 /* ConversationSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationSummary.swift; sourceTree = "<group>"; };
+               F15BC5012E0AC1AB00F25923 /* FetchConversationsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchConversationsUseCase.swift; sourceTree = "<group>"; };
+               D1429C4B96A13E73C35752E4 /* UpdateConversationTitleUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateConversationTitleUseCase.swift; sourceTree = "<group>"; };
+               64EB7DD9103C65295FB89E7C /* DeleteConversationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteConversationUseCase.swift; sourceTree = "<group>"; };
+               F16563C82DF9A30F001CDF3B /* chatGPT.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = chatGPT.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F16563DE2DF9A310001CDF3B /* chatGPTTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = chatGPTTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F16563E82DF9A310001CDF3B /* chatGPTUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = chatGPTUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F166CA0B2DF9A39B00AAB5B0 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -405,10 +409,12 @@
 				f495b15056fc494682c60df5 /* SendChatWithContextUseCase.swift */,
 				896db1fb7f9843dbb43a9831 /* SignOutUseCase.swift */,
 				eef3624df55348a684cdc5fd /* LoadUserProfileImageUseCase.swift */,
-				9b8f82223d524f878b330338 /* ObserveAuthStateUseCase.swift */,
-				79766A3D81B253405488FCA1 /* AppendMessageUseCase.swift */,
-				3e924cb7e10d40a1a28fc225 /* ObserveConversationsUseCase.swift */,
-			);
+                               9b8f82223d524f878b330338 /* ObserveAuthStateUseCase.swift */,
+                               79766A3D81B253405488FCA1 /* AppendMessageUseCase.swift */,
+                               3e924cb7e10d40a1a28fc225 /* ObserveConversationsUseCase.swift */,
+                               D1429C4B96A13E73C35752E4 /* UpdateConversationTitleUseCase.swift */,
+                               64EB7DD9103C65295FB89E7C /* DeleteConversationUseCase.swift */,
+                       );
 			path = UseCase;
 			sourceTree = "<group>";
 		};
@@ -711,10 +717,12 @@
 				4f89184b5697445da8d67bb5 /* SignOutUseCase.swift in Sources */,
 				F1DF3B152DF9B09200D8445A /* AppCoordinator.swift in Sources */,
 				F166CA142DF9A39B00AAB5B0 /* SceneDelegate.swift in Sources */,
-				a0d99ba381b44d72b54327f6 /* MenuViewController.swift in Sources */,
-				F1DF3B182DF9B0E100D8445A /* APIKeyInputViewController.swift in Sources */,
-				F122E5D42E0C0352006E81DD /* FetchConversationMessagesUseCase.swift in Sources */,
-			);
+                               a0d99ba381b44d72b54327f6 /* MenuViewController.swift in Sources */,
+                               F1DF3B182DF9B0E100D8445A /* APIKeyInputViewController.swift in Sources */,
+                               F122E5D42E0C0352006E81DD /* FetchConversationMessagesUseCase.swift in Sources */,
+                               FDF214A9E94D3F7E2DA0DEED /* UpdateConversationTitleUseCase.swift in Sources */,
+                               679ABD2960C6FE51CF51C1D7 /* DeleteConversationUseCase.swift in Sources */,
+                       );
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		F16563DA2DF9A310001CDF3B /* Sources */ = {

--- a/chatGPT/Data/FirestoreConversationRepository.swift
+++ b/chatGPT/Data/FirestoreConversationRepository.swift
@@ -132,6 +132,32 @@ final class FirestoreConversationRepository: ConversationRepository {
         }
     }
 
+    func updateTitle(uid: String, conversationID: String, title: String) -> Single<Void> {
+        Single.create { single in
+            self.db.collection(uid).document(conversationID).updateData(["title": title]) { error in
+                if let error = error {
+                    single(.failure(error))
+                } else {
+                    single(.success(()))
+                }
+            }
+            return Disposables.create()
+        }
+    }
+
+    func deleteConversation(uid: String, conversationID: String) -> Single<Void> {
+        Single.create { single in
+            self.db.collection(uid).document(conversationID).delete { error in
+                if let error = error {
+                    single(.failure(error))
+                } else {
+                    single(.success(()))
+                }
+            }
+            return Disposables.create()
+        }
+    }
+
     deinit {
         listener?.remove()
     }

--- a/chatGPT/Domain/Repository/ConversationRepository.swift
+++ b/chatGPT/Domain/Repository/ConversationRepository.swift
@@ -15,4 +15,6 @@ protocol ConversationRepository {
     func fetchConversations(uid: String) -> Single<[ConversationSummary]>
     func fetchMessages(uid: String, conversationID: String) -> Single<[ConversationMessage]>
     func observeConversations(uid: String) -> Observable<[ConversationSummary]>
+    func updateTitle(uid: String, conversationID: String, title: String) -> Single<Void>
+    func deleteConversation(uid: String, conversationID: String) -> Single<Void>
 }

--- a/chatGPT/Domain/UseCase/DeleteConversationUseCase.swift
+++ b/chatGPT/Domain/UseCase/DeleteConversationUseCase.swift
@@ -1,0 +1,21 @@
+import Foundation
+import RxSwift
+
+final class DeleteConversationUseCase {
+    private let repository: ConversationRepository
+    private let getCurrentUserUseCase: GetCurrentUserUseCase
+
+    init(repository: ConversationRepository,
+         getCurrentUserUseCase: GetCurrentUserUseCase) {
+        self.repository = repository
+        self.getCurrentUserUseCase = getCurrentUserUseCase
+    }
+
+    func execute(conversationID: String) -> Single<Void> {
+        guard let user = getCurrentUserUseCase.execute() else {
+            return .error(ConversationError.noUser)
+        }
+        return repository.deleteConversation(uid: user.uid,
+                                             conversationID: conversationID)
+    }
+}

--- a/chatGPT/Domain/UseCase/UpdateConversationTitleUseCase.swift
+++ b/chatGPT/Domain/UseCase/UpdateConversationTitleUseCase.swift
@@ -1,0 +1,22 @@
+import Foundation
+import RxSwift
+
+final class UpdateConversationTitleUseCase {
+    private let repository: ConversationRepository
+    private let getCurrentUserUseCase: GetCurrentUserUseCase
+
+    init(repository: ConversationRepository,
+         getCurrentUserUseCase: GetCurrentUserUseCase) {
+        self.repository = repository
+        self.getCurrentUserUseCase = getCurrentUserUseCase
+    }
+
+    func execute(conversationID: String, title: String) -> Single<Void> {
+        guard let user = getCurrentUserUseCase.execute() else {
+            return .error(ConversationError.noUser)
+        }
+        return repository.updateTitle(uid: user.uid,
+                                      conversationID: conversationID,
+                                      title: title)
+    }
+}

--- a/chatGPT/Presentation/Coordinator/AppCoordinator.swift
+++ b/chatGPT/Presentation/Coordinator/AppCoordinator.swift
@@ -72,6 +72,14 @@ final class AppCoordinator {
             repository: conversationRepository,
             getCurrentUserUseCase: getCurrentUserUseCase
         )
+        let updateTitleUseCase = UpdateConversationTitleUseCase(
+            repository: conversationRepository,
+            getCurrentUserUseCase: getCurrentUserUseCase
+        )
+        let deleteConversationUseCase = DeleteConversationUseCase(
+            repository: conversationRepository,
+            getCurrentUserUseCase: getCurrentUserUseCase
+        )
         observeConversationsUseCase.execute()
             .subscribe()
             .disposed(by: disposeBag)
@@ -95,6 +103,8 @@ final class AppCoordinator {
             contextRepository: contextRepository,
             observeConversationsUseCase: observeConversationsUseCase,
             signOutUseCase: signOutUseCase,
+            updateTitleUseCase: updateTitleUseCase,
+            deleteConversationUseCase: deleteConversationUseCase,
             loadUserImageUseCase: loadUserImageUseCase,
             observeAuthStateUseCase: observeAuthStateUseCase,
             parseMarkdownUseCase: parseMarkdownUseCase

--- a/chatGPT/Presentation/Scene/MainViewController.swift
+++ b/chatGPT/Presentation/Scene/MainViewController.swift
@@ -19,6 +19,8 @@ final class MainViewController: UIViewController {
     private let chatViewModel: ChatViewModel
     private let signOutUseCase: SignOutUseCase
     private let observeConversationsUseCase: ObserveConversationsUseCase
+    private let updateTitleUseCase: UpdateConversationTitleUseCase
+    private let deleteConversationUseCase: DeleteConversationUseCase
     private let loadUserImageUseCase: LoadUserProfileImageUseCase
     private let observeAuthStateUseCase: ObserveAuthStateUseCase
     private let parseMarkdownUseCase: ParseMarkdownUseCase
@@ -62,6 +64,8 @@ final class MainViewController: UIViewController {
             observeConversationsUseCase: observeConversationsUseCase,
             signOutUseCase: signOutUseCase,
             fetchModelsUseCase: fetchModelsUseCase,
+            updateTitleUseCase: updateTitleUseCase,
+            deleteConversationUseCase: deleteConversationUseCase,
             selectedModel: selectedModel,
             streamEnabled: streamEnabled,
             currentConversationID: chatViewModel.conversationID,
@@ -124,14 +128,16 @@ final class MainViewController: UIViewController {
          sendChatMessageUseCase: SendChatWithContextUseCase,
          summarizeUseCase: SummarizeMessagesUseCase,
          saveConversationUseCase: SaveConversationUseCase,
-         appendMessageUseCase: AppendMessageUseCase,
-         fetchConversationMessagesUseCase: FetchConversationMessagesUseCase,
-         contextRepository: ChatContextRepository,
-        observeConversationsUseCase: ObserveConversationsUseCase,
-        signOutUseCase: SignOutUseCase,
-        loadUserImageUseCase: LoadUserProfileImageUseCase,
-         observeAuthStateUseCase: ObserveAuthStateUseCase,
-         parseMarkdownUseCase: ParseMarkdownUseCase) {
+        appendMessageUseCase: AppendMessageUseCase,
+        fetchConversationMessagesUseCase: FetchConversationMessagesUseCase,
+        contextRepository: ChatContextRepository,
+       observeConversationsUseCase: ObserveConversationsUseCase,
+       signOutUseCase: SignOutUseCase,
+       updateTitleUseCase: UpdateConversationTitleUseCase,
+       deleteConversationUseCase: DeleteConversationUseCase,
+       loadUserImageUseCase: LoadUserProfileImageUseCase,
+        observeAuthStateUseCase: ObserveAuthStateUseCase,
+        parseMarkdownUseCase: ParseMarkdownUseCase) {
         self.fetchModelsUseCase = fetchModelsUseCase
         self.chatViewModel = ChatViewModel(sendMessageUseCase: sendChatMessageUseCase,
                                            summarizeUseCase: summarizeUseCase,
@@ -141,6 +147,8 @@ final class MainViewController: UIViewController {
                                            contextRepository: contextRepository)
         self.signOutUseCase = signOutUseCase
         self.observeConversationsUseCase = observeConversationsUseCase
+        self.updateTitleUseCase = updateTitleUseCase
+        self.deleteConversationUseCase = deleteConversationUseCase
         self.loadUserImageUseCase = loadUserImageUseCase
         self.observeAuthStateUseCase = observeAuthStateUseCase
         self.parseMarkdownUseCase = parseMarkdownUseCase

--- a/chatGPT/Presentation/Scene/MenuViewController.swift
+++ b/chatGPT/Presentation/Scene/MenuViewController.swift
@@ -24,6 +24,8 @@ final class MenuViewController: UIViewController {
     private let observeConversationsUseCase: ObserveConversationsUseCase
     private let signOutUseCase: SignOutUseCase
     private let fetchModelsUseCase: FetchAvailableModelsUseCase
+    private let updateTitleUseCase: UpdateConversationTitleUseCase
+    private let deleteConversationUseCase: DeleteConversationUseCase
     private var currentConversationID: String?
     private let draftExists: Bool
     private let disposeBag = DisposeBag()
@@ -57,6 +59,8 @@ final class MenuViewController: UIViewController {
     init(observeConversationsUseCase: ObserveConversationsUseCase,
          signOutUseCase: SignOutUseCase,
          fetchModelsUseCase: FetchAvailableModelsUseCase,
+         updateTitleUseCase: UpdateConversationTitleUseCase,
+         deleteConversationUseCase: DeleteConversationUseCase,
          selectedModel: OpenAIModel,
          streamEnabled: Bool,
          currentConversationID: String?,
@@ -66,6 +70,8 @@ final class MenuViewController: UIViewController {
         self.observeConversationsUseCase = observeConversationsUseCase
         self.signOutUseCase = signOutUseCase
         self.fetchModelsUseCase = fetchModelsUseCase
+        self.updateTitleUseCase = updateTitleUseCase
+        self.deleteConversationUseCase = deleteConversationUseCase
         self.selectedModel = selectedModel
         self.streamEnabled = streamEnabled
         self.currentConversationID = currentConversationID
@@ -182,6 +188,27 @@ final class MenuViewController: UIViewController {
         return UIMenu(title: "", options: .displayInline, children: actions)
     }
 
+    private func showEditAlert(convo: ConversationSummary) {
+        let alert = UIAlertController(title: "제목 수정", message: nil, preferredStyle: .alert)
+        alert.addTextField { textField in
+            textField.text = convo.title
+        }
+        alert.addAction(UIAlertAction(title: "취소", style: .cancel))
+        alert.addAction(UIAlertAction(title: "저장", style: .default) { [weak self, weak alert] _ in
+            guard let self, let title = alert?.textFields?.first?.text, !title.isEmpty else { return }
+            self.updateTitleUseCase.execute(conversationID: convo.id, title: title)
+                .subscribe()
+                .disposed(by: self.disposeBag)
+        })
+        present(alert, animated: true)
+    }
+
+    private func deleteConversation(id: String) {
+        deleteConversationUseCase.execute(conversationID: id)
+            .subscribe()
+            .disposed(by: disposeBag)
+    }
+
 }
 
 extension MenuViewController: UITableViewDelegate, UITableViewDataSource {
@@ -257,6 +284,24 @@ extension MenuViewController: UITableViewDelegate, UITableViewDataSource {
 
     func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
         Section(rawValue: section) == .setting ? 40 : .leastNormalMagnitude
+    }
+
+    func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        guard Section(rawValue: indexPath.section) == .history else { return nil }
+        let convo = conversations[indexPath.row]
+        guard convo.id != "draft" else { return nil }
+
+        let edit = UIContextualAction(style: .normal, title: "수정") { [weak self] _, _, completion in
+            self?.showEditAlert(convo: convo)
+            completion(true)
+        }
+        edit.backgroundColor = ThemeColor.background3
+
+        let delete = UIContextualAction(style: .destructive, title: "삭제") { [weak self] _, _, completion in
+            self?.deleteConversation(id: convo.id)
+            completion(true)
+        }
+        return UISwipeActionsConfiguration(actions: [delete, edit])
     }
 }
 


### PR DESCRIPTION
## Summary
- enable title editing and deletion in chat history
- support update and delete use cases in data layer
- expose new use cases to UI
- integrate swipe actions for conversation cells

## Testing
- `swift test -c release` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_686639f54e08832b9f377a0ad8c381b6