### PR TITLE
Update conversation deletion handling

### DIFF
--- a/chatGPT/Presentation/Scene/MainViewController.swift
+++ b/chatGPT/Presentation/Scene/MainViewController.swift
@@ -91,6 +91,12 @@ final class MainViewController: UIViewController {
                 }
             }
         }
+        menuVC.onConversationDeleted = { [weak self] id in
+            guard let self else { return }
+            if self.chatViewModel.conversationID == id {
+                self.chatViewModel.startNewConversation()
+            }
+        }
         menuVC.onClose = { [weak menuVC] in
             menuVC?.dismiss(animated: true)
         }

--- a/chatGPT/Presentation/Scene/MenuViewController.swift
+++ b/chatGPT/Presentation/Scene/MenuViewController.swift
@@ -43,6 +43,7 @@ final class MenuViewController: UIViewController {
     // 메뉴 닫기용 클로저
     var onClose: (() -> Void)?
     var onConversationSelected: ((String?) -> Void)?
+    var onConversationDeleted: ((String) -> Void)?
 
     private lazy var tableView: UITableView = {
         let tv = UITableView(frame: .zero, style: .grouped)
@@ -205,7 +206,14 @@ final class MenuViewController: UIViewController {
 
     private func deleteConversation(id: String) {
         deleteConversationUseCase.execute(conversationID: id)
-            .subscribe()
+            .observe(on: MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] in
+                guard let self else { return }
+                if self.currentConversationID == id {
+                    self.currentConversationID = nil
+                    self.onConversationDeleted?(id)
+                }
+            })
             .disposed(by: disposeBag)
     }
 


### PR DESCRIPTION
## Summary
- notify conversation deletion from menu
- reset chat state in main view after deleting current chat

## Testing
- `swift test` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_68663eb62634832bb67f3b523e7d9eb2