### PR TITLE
Change edit action color

### DIFF
--- a/chatGPT/Presentation/Scene/MenuViewController.swift
+++ b/chatGPT/Presentation/Scene/MenuViewController.swift
@@ -303,7 +303,7 @@ extension MenuViewController: UITableViewDelegate, UITableViewDataSource {
             self?.showEditAlert(convo: convo)
             completion(true)
         }
-        edit.backgroundColor = ThemeColor.background3
+        edit.backgroundColor = ThemeColor.positive
 
         let delete = UIContextualAction(style: .destructive, title: "삭제") { [weak self] _, _, completion in
             self?.deleteConversation(id: convo.id)


### PR DESCRIPTION
## Summary
- use `ThemeColor.positive` for the edit swipe action

## Testing
- `swift test` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_686bd1015014832b88c502d22c3e4f67