### PR TITLE
Add Firestore security rules guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,3 +149,8 @@ func execute(prompt: String, model: OpenAIModel, completion: @escaping (Result<S
 
 
 
+
+## 🔒 Firestore 보안 규칙
+
+Firestore에 저장되는 `preferences` 컬렉션과 대화 데이터는 인증된 사용자만 접근할 수 있도록 권한을 설정해야 합니다.
+Firebase 콘솔의 **Firestore Database > 규칙** 탭에서 [`firebase/firestore_rules.md`](firebase/firestore_rules.md) 파일의 내용을 적용하세요.

--- a/firebase/firestore_rules.md
+++ b/firebase/firestore_rules.md
@@ -1,0 +1,20 @@
+# Firestore 보안 규칙 예시
+
+Firebase 콘솔에서 **Firestore Database** 메뉴의 **규칙** 탭에 아래 내용을 설정하세요.
+
+```javascript
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    // preferences 컬렉션
+    match /preferences/{userId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
+    // 대화 데이터 (사용자 UID를 최상위 컬렉션 이름으로 사용)
+    match /{userId}/{conversationId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+  }
+}
+```


### PR DESCRIPTION
## Summary
- document recommended Firestore rules
- link from README to the new rules file

## Testing
- `swift test` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_686bdd517028832babf1783892b89656