### PR TITLE
Fix optional chaining

### DIFF
--- a/chatGPT/Data/FirestoreUserPreferenceRepository.swift
+++ b/chatGPT/Data/FirestoreUserPreferenceRepository.swift
@@ -26,7 +26,7 @@ final class FirestoreUserPreferenceRepository: UserPreferenceRepository {
         Single.create { single in
             let doc = self.db.collection("preferences").document(uid)
             doc.getDocument { snapshot, error in
-                var topics = snapshot?.data()? ["topics"] as? [String: Double] ?? [:]
+                var topics = snapshot?.data()?["topics"] as? [String: Double] ?? [:]
                 tokens.forEach { token in
                     topics[token, default: 0] += 1
                 }


### PR DESCRIPTION
## Summary
- fix optional chaining usage in FirestoreUserPreferenceRepository

## Testing
- `swift test` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_686bdd45e848832bb2e3211cb5753014