### PR TITLE
Implement preference relation storage

### DIFF
--- a/chatGPT/Data/FirestoreUserPreferenceRepository.swift
+++ b/chatGPT/Data/FirestoreUserPreferenceRepository.swift
@@ -7,11 +7,20 @@ final class FirestoreUserPreferenceRepository: UserPreferenceRepository {
 
     func fetch(uid: String) -> Single<UserPreference?> {
         Single.create { single in
-            self.db.collection("preferences").document(uid).getDocument { doc, error in
-                if let data = doc?.data() {
-                    let topics = data["topics"] as? [String: Double] ?? [:]
-                    let style = data["style"] as? [String: Double] ?? [:]
-                    single(.success(UserPreference(topics: topics, style: style)))
+            self.db.collection("preferences").document(uid).collection("items").getDocuments { snapshot, error in
+                if let docs = snapshot?.documents {
+                    let items: [PreferenceItem] = docs.compactMap { doc in
+                        let data = doc.data()
+                        guard
+                            let key = data["key"] as? String,
+                            let raw = data["relation"] as? String,
+                            let relation = PreferenceRelation(rawValue: raw),
+                            let updatedAt = data["updatedAt"] as? TimeInterval,
+                            let count = data["count"] as? Int
+                        else { return nil }
+                        return PreferenceItem(key: key, relation: relation, updatedAt: updatedAt, count: count)
+                    }
+                    single(.success(UserPreference(items: items)))
                 } else if let error = error {
                     single(.failure(error))
                 } else {
@@ -22,22 +31,42 @@ final class FirestoreUserPreferenceRepository: UserPreferenceRepository {
         }
     }
 
-    func update(uid: String, tokens: [String]) -> Single<Void> {
-        Single.create { single in
-            let doc = self.db.collection("preferences").document(uid)
-            doc.getDocument { snapshot, error in
-                var topics = snapshot?.data()?["topics"] as? [String: Double] ?? [:]
-                tokens.forEach { token in
-                    topics[token, default: 0] += 1
-                }
-                doc.setData(["topics": topics], merge: true) { error in
-                    if let error = error {
-                        single(.failure(error))
-                    } else {
-                        single(.success(()))
+    func update(uid: String, items: [PreferenceItem]) -> Single<Void> {
+        guard !items.isEmpty else { return .just(()) }
+        return Single.create { single in
+            let group = DispatchGroup()
+            var firstError: Error?
+
+            items.forEach { item in
+                group.enter()
+                let doc = self.db.collection("preferences")
+                    .document(uid)
+                    .collection("items")
+                    .document("\(item.key)_\(item.relation.rawValue)")
+                doc.getDocument { snapshot, error in
+                    if let error = error { firstError = error; group.leave(); return }
+                    let count = (snapshot?.data()? ["count"] as? Int ?? 0) + 1
+                    let data: [String: Any] = [
+                        "key": item.key,
+                        "relation": item.relation.rawValue,
+                        "count": count,
+                        "updatedAt": item.updatedAt
+                    ]
+                    doc.setData(data) { err in
+                        if let err = err { firstError = err }
+                        group.leave()
                     }
                 }
             }
+
+            group.notify(queue: .main) {
+                if let error = firstError {
+                    single(.failure(error))
+                } else {
+                    single(.success(()))
+                }
+            }
+
             return Disposables.create()
         }
     }

--- a/chatGPT/Domain/Entity/UserPreference.swift
+++ b/chatGPT/Domain/Entity/UserPreference.swift
@@ -1,6 +1,19 @@
 import Foundation
 
+enum PreferenceRelation: String, Codable {
+    case like
+    case dislike
+    case want
+    case avoid
+}
+
+struct PreferenceItem: Codable {
+    let key: String
+    let relation: PreferenceRelation
+    let updatedAt: TimeInterval
+    var count: Int
+}
+
 struct UserPreference: Codable {
-    var topics: [String: Double]
-    var style: [String: Double]
+    var items: [PreferenceItem]
 }

--- a/chatGPT/Domain/Repository/UserPreferenceRepository.swift
+++ b/chatGPT/Domain/Repository/UserPreferenceRepository.swift
@@ -3,5 +3,5 @@ import RxSwift
 
 protocol UserPreferenceRepository {
     func fetch(uid: String) -> Single<UserPreference?>
-    func update(uid: String, tokens: [String]) -> Single<Void>
+    func update(uid: String, items: [PreferenceItem]) -> Single<Void>
 }

--- a/chatGPT/Domain/UseCase/UpdateUserPreferenceUseCase.swift
+++ b/chatGPT/Domain/UseCase/UpdateUserPreferenceUseCase.swift
@@ -14,8 +14,34 @@ final class UpdateUserPreferenceUseCase {
         guard let user = getCurrentUserUseCase.execute() else {
             return .error(PreferenceError.noUser)
         }
+        let items = self.parse(prompt: prompt)
+        return repository.update(uid: user.uid, items: items)
+    }
+
+    private func parse(prompt: String) -> [PreferenceItem] {
         let tokens = prompt.split { $0.isWhitespace || $0.isPunctuation }
-            .map { String($0).lowercased() }
-        return repository.update(uid: user.uid, tokens: tokens)
+            .map { String($0) }
+        var items: [PreferenceItem] = []
+        for (index, token) in tokens.enumerated() {
+            let time = Date().timeIntervalSince1970
+            if token.contains("좋아") && index > 0 {
+                let key = tokens[index - 1]
+                let item = PreferenceItem(key: key, relation: .like, updatedAt: time, count: 1)
+                items.append(item)
+            } else if token.contains("싫어") && index > 0 {
+                let key = tokens[index - 1]
+                let item = PreferenceItem(key: key, relation: .dislike, updatedAt: time, count: 1)
+                items.append(item)
+            } else if (token.contains("원해") || token.contains("해줘")) && index > 0 {
+                let key = tokens[index - 1]
+                let item = PreferenceItem(key: key, relation: .want, updatedAt: time, count: 1)
+                items.append(item)
+            } else if (token.contains("원하지") || token.contains("하지마")) && index > 0 {
+                let key = tokens[index - 1]
+                let item = PreferenceItem(key: key, relation: .avoid, updatedAt: time, count: 1)
+                items.append(item)
+            }
+        }
+        return items
     }
 }

--- a/chatGPT/Presentation/Scene/ChatViewModel.swift
+++ b/chatGPT/Presentation/Scene/ChatViewModel.swift
@@ -166,10 +166,10 @@ final class ChatViewModel {
 
     private func preferenceText(from preference: UserPreference?) -> String? {
         guard let preference else { return nil }
-        let sorted = preference.topics.sorted { $0.value > $1.value }
-        let topics = sorted.map { $0.key }.joined(separator: ", ")
-        guard !topics.isEmpty else { return nil }
-        return "사용자가 선호하는 주제: " + topics
+        let sorted = preference.items.sorted { $0.updatedAt > $1.updatedAt }
+        let texts = sorted.map { "\($0.relation.rawValue): \($0.key)" }
+        let result = texts.joined(separator: ", ")
+        return result.isEmpty ? nil : result
     }
     
     private func saveFirstConversation(question: String, answer: String, model: OpenAIModel) {


### PR DESCRIPTION
## Summary
- enhance `UserPreference` with relation and timestamp
- store preference items in Firestore
- detect relations when updating preference
- format preference info in `ChatViewModel`

## Testing
- `swift build` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_686d03dd0fa0832bb9c79615f1095e7d