### PR TITLE
Unify Firestore path layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,5 +152,5 @@ func execute(prompt: String, model: OpenAIModel, completion: @escaping (Result<S
 
 ## 🔒 Firestore 보안 규칙
 
-Firestore에 저장되는 `preferences` 컬렉션과 대화 데이터는 인증된 사용자만 접근할 수 있도록 권한을 설정해야 합니다.
+Firestore에 저장되는 `preferences`와 `conversations` 컬렉션은 인증된 사용자만 접근할 수 있도록 권한을 설정해야 합니다.
 Firebase 콘솔의 **Firestore Database > 규칙** 탭에서 [`firebase/firestore_rules.md`](firebase/firestore_rules.md) 파일의 내용을 적용하세요.

--- a/firebase/firestore_rules.md
+++ b/firebase/firestore_rules.md
@@ -11,8 +11,8 @@ service cloud.firestore {
       allow read, write: if request.auth != null && request.auth.uid == userId;
     }
 
-    // 대화 데이터 (사용자 UID를 최상위 컬렉션 이름으로 사용)
-    match /{userId}/{conversationId} {
+    // conversations 컬렉션
+    match /conversations/{userId}/items/{conversationId} {
       allow read, write: if request.auth != null && request.auth.uid == userId;
     }
   }


### PR DESCRIPTION
## Summary
- store conversation data under `conversations/{uid}/items/{conversationId}`
- update Firestore rules for the new structure
- clarify collections in README

## Testing
- `swift test` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_686d13aea8f8832b8331a55c44ca7bb6