### PR TITLE
Show draft conversation when list empty

### DIFF
--- a/chatGPT/Presentation/Scene/MenuViewController.swift
+++ b/chatGPT/Presentation/Scene/MenuViewController.swift
@@ -146,6 +146,14 @@ final class MenuViewController: UIViewController {
     }
 
     private func load() {
+        var initial: [ConversationSummary] = []
+        if currentConversationID == nil || draftExists {
+            let draft = ConversationSummary(id: "draft", title: "새로운 대화", timestamp: Date())
+            initial.append(draft)
+        }
+        conversations = initial
+        tableView.reloadData()
+
         observeConversationsUseCase.execute()
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] list in


### PR DESCRIPTION
## Summary
- ensure draft conversation item appears immediately

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d158f4808832b8456d4bad6b0d41a