### PR TITLE
Hide past chat header if empty

### DIFF
--- a/chatGPT/Presentation/Scene/MenuViewController.swift
+++ b/chatGPT/Presentation/Scene/MenuViewController.swift
@@ -285,7 +285,14 @@ extension MenuViewController: UITableViewDelegate, UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        Section(rawValue: section)?.title
+        guard let section = Section(rawValue: section) else { return nil }
+        switch section {
+        case .setting:
+            return section.title
+        case .history:
+            let hasHistory = conversations.contains { $0.id != "draft" }
+            return hasHistory ? section.title : nil
+        }
     }
 
     func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {


### PR DESCRIPTION
## Summary
- avoid showing 'Past Conversations' header when there are no stored chats

## Testing
- `swift test --enable-code-coverage` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_686d1768ef3c832b902bde3ea9f3221d