### PR TITLE
Update menu header logic

### DIFF
--- a/chatGPT/Presentation/Scene/MenuViewController.swift
+++ b/chatGPT/Presentation/Scene/MenuViewController.swift
@@ -290,8 +290,8 @@ extension MenuViewController: UITableViewDelegate, UITableViewDataSource {
         case .setting:
             return section.title
         case .history:
-            let hasHistory = conversations.contains { $0.id != "draft" }
-            return hasHistory ? section.title : nil
+            let hasItem = !conversations.isEmpty
+            return hasItem ? section.title : nil
         }
     }
 


### PR DESCRIPTION
## Summary
- show 'history' header even if only draft chat exists

## Testing
- `swift test` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_686d1bdfdd68832bbda3338e76818ab2