### PR TITLE
Improve streaming view update

### DIFF
--- a/chatGPT/Presentation/Scene/Cells/ChatMessageCell.swift
+++ b/chatGPT/Presentation/Scene/Cells/ChatMessageCell.swift
@@ -211,7 +211,19 @@ final class ChatMessageCell: UITableViewCell {
     }
 
     @discardableResult
-    func update(text: String, parser: ParseMarkdownUseCase) -> Bool {
+    func update(text: String,
+                parser: ParseMarkdownUseCase,
+                streaming: Bool = false) -> Bool {
+        if streaming {
+            messageView.text = text
+            stackView.isHidden = true
+            messageView.isHidden = false
+            layoutIfNeeded()
+            let newHeight = messageView.contentSize.height
+            defer { lastHeight = newHeight }
+            return newHeight != lastHeight
+        }
+
         if stackView.isHidden {
             messageView.attributedText = parser.execute(markdown: text)
             layoutIfNeeded()

--- a/chatGPT/Presentation/Scene/MainViewController.swift
+++ b/chatGPT/Presentation/Scene/MainViewController.swift
@@ -251,7 +251,9 @@ final class MainViewController: UIViewController {
                 
                 // 셀을 찾아 직접 업데이트
                 if let cell = self.tableView.cellForRow(at: indexPath) as? ChatMessageCell {
-                    let heightChanged = cell.update(text: message.text, parser: self.parseMarkdownUseCase)
+                    let heightChanged = cell.update(text: message.text,
+                                                  parser: self.parseMarkdownUseCase,
+                                                  streaming: true)
                     if heightChanged {
                         UIView.performWithoutAnimation {
                             self.tableView.beginUpdates()


### PR DESCRIPTION
## Summary
- avoid markdown parsing while streaming updates
- update message cell with plain text during streaming

## Testing
- `swift build --product chatGPT` *(fails: no such module 'UIKit')*
- `swift test` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_686d3234f9e4832b8e7cc04ae6aca7ec