### PR TITLE
Add heading parsing

### DIFF
--- a/chatGPT/Data/SwiftMarkdownRepository.swift
+++ b/chatGPT/Data/SwiftMarkdownRepository.swift
@@ -58,6 +58,40 @@ final class SwiftMarkdownRepository: MarkdownRepository {
                 if let attachment = makeTableAttachment(from: tableLines) {
                     result.append(NSAttributedString(attachment: attachment))
                 }
+            } else if let headingLevel = headingLevel(in: line) {
+                let content = headingContent(from: line, level: headingLevel)
+
+                var options = AttributedString.MarkdownParsingOptions()
+                options.interpretedSyntax = .inlineOnlyPreservingWhitespace
+                options.allowsExtendedAttributes = true
+
+                let fontSize: CGFloat
+                switch headingLevel {
+                case 1: fontSize = 28
+                case 2: fontSize = 24
+                default: fontSize = 20
+                }
+
+                if var attr = try? AttributedString(markdown: content, options: options) {
+                    for run in attr.runs {
+                        let range = run.range
+                        if run.inlinePresentationIntent == .code {
+                            attr[range].font = UIFont(name: "Menlo", size: 16) ?? UIFont.monospacedSystemFont(ofSize: 16, weight: .regular)
+                            attr[range].foregroundColor = ThemeColor.negative
+                            attr[range].backgroundColor = ThemeColor.inlineCodeBackground
+                        } else {
+                            attr[range].font = UIFont.boldSystemFont(ofSize: fontSize)
+                            attr[range].foregroundColor = UIColor.label
+                        }
+                    }
+                    result.append(NSAttributedString(attr))
+                } else {
+                    result.append(NSAttributedString(string: content, attributes: [
+                        .font: UIFont.boldSystemFont(ofSize: fontSize),
+                        .foregroundColor: UIColor.label
+                    ]))
+                }
+                index += 1
             } else if line.trimmingCharacters(in: .whitespaces).hasPrefix("- ") {
                 var listLines: [String] = []
                 while index < lines.count && lines[index].trimmingCharacters(in: .whitespaces).hasPrefix("- ") {
@@ -157,5 +191,19 @@ final class SwiftMarkdownRepository: MarkdownRepository {
         if temp.hasPrefix("|") { temp.removeFirst() }
         if temp.hasSuffix("|") { temp.removeLast() }
         return temp.split(separator: "|").map { $0.trimmingCharacters(in: .whitespaces) }
+    }
+
+    private func headingLevel(in line: String) -> Int? {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        if trimmed.hasPrefix("### ") { return 3 }
+        if trimmed.hasPrefix("## ") { return 2 }
+        if trimmed.hasPrefix("# ") { return 1 }
+        return nil
+    }
+
+    private func headingContent(from line: String, level: Int) -> String {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        let start = trimmed.index(trimmed.startIndex, offsetBy: level + 1)
+        return String(trimmed[start...])
     }
 }


### PR DESCRIPTION
## Summary
- support H1-H3 headings in Markdown parser

## Testing
- `swift test -l` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_686e290c412c832b948deb2202b3c8b4