### PR TITLE
Fix bullet color for markdown list

### DIFF
--- a/chatGPT/Data/SwiftMarkdownRepository.swift
+++ b/chatGPT/Data/SwiftMarkdownRepository.swift
@@ -174,7 +174,14 @@ final class SwiftMarkdownRepository: MarkdownRepository {
                         attr[range].foregroundColor = UIColor.label
                     }
                 }
-                result.append(NSAttributedString(string: "\u{2022} "))
+                let bullet = NSAttributedString(
+                    string: "\u{2022} ",
+                    attributes: [
+                        .font: UIFont.systemFont(ofSize: 16),
+                        .foregroundColor: UIColor.label
+                    ]
+                )
+                result.append(bullet)
                 result.append(NSAttributedString(attr))
             } else {
                 result.append(NSAttributedString(string: "\u{2022} " + item, attributes: [


### PR DESCRIPTION
## Summary
- ensure bullet color matches text color in markdown list

## Testing
- `swift test` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_686e4211b97c832b910958fc24218c31