### PR TITLE
Fix code block width

### DIFF
--- a/chatGPT/Components/CodeBlockAttachment.swift
+++ b/chatGPT/Components/CodeBlockAttachment.swift
@@ -18,7 +18,8 @@ final class CodeBlockAttachment: NSTextAttachment {
 
     override func attachmentBounds(for textContainer: NSTextContainer?, proposedLineFragment lineFrag: CGRect, glyphPosition position: CGPoint, characterIndex charIndex: Int) -> CGRect {
         let targetWidth = lineFrag.width
-        let size = view.systemLayoutSizeFitting(CGSize(width: targetWidth, height: .greatestFiniteMagnitude))
+        var size = view.systemLayoutSizeFitting(CGSize(width: targetWidth, height: .greatestFiniteMagnitude))
+        size.width = max(size.width, targetWidth)
         return CGRect(origin: .zero, size: size)
     }
 }


### PR DESCRIPTION
## Summary
- ensure code block view always expands to available width

## Testing
- `swift test` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_686e5d733dd4832b86a0ed70a6133c83