### PR TITLE
Fix code block width

### DIFF
--- a/chatGPT/Presentation/Helpers/UITextView+Attachment.swift
+++ b/chatGPT/Presentation/Helpers/UITextView+Attachment.swift
@@ -36,7 +36,9 @@ extension UITextView {
               let textRange = textRange(from: start, to: end) else {
             return .zero
         }
-        let rect = firstRect(for: textRange)
-        return rect.integral
+        let rect = firstRect(for: textRange).integral
+        let padding = textContainerInset.left + textContainer.lineFragmentPadding
+        let width = bounds.width - padding * 2
+        return CGRect(x: padding, y: rect.minY, width: width, height: rect.height)
     }
 }


### PR DESCRIPTION
## Summary
- fix code block layout to occupy full width even with short content

## Testing
- `swift test` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_686e5f2fe870832b81a55a62463b168d