### PR TITLE
Fix indented code block parsing

### DIFF
--- a/chatGPT/Data/SwiftMarkdownRepository.swift
+++ b/chatGPT/Data/SwiftMarkdownRepository.swift
@@ -7,7 +7,7 @@ final class SwiftMarkdownRepository: MarkdownRepository {
     // 코드 블럭 내부에 ``` 문자열이 포함되어도 올바르게 파싱되도록 개선합니다.
     // 닫는 백틱 뒤에 공백이 올 수 있도록 패턴을 보강합니다.
     private let codeRegex = try! NSRegularExpression(
-        pattern: "(`{3,})([^\\r\\n]*?)\\r?\\n([\\s\\S]*?)\\r?\\n\\1[ \\t]*(?:\\r?\\n|$)",
+        pattern: "(?:^|\\n)[ \\t]*(`{3,})([^\\r\\n]*?)\\r?\\n([\\s\\S]*?)\\r?\\n[ \\t]*\\1[ \\t]*(?=\\r?\\n|$)",
         options: []
     )
     


### PR DESCRIPTION
## Summary
- update code block regex to accept leading spaces

## Testing
- `swift test -l` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_686fb5099ca0832b89a822f8c921c295