### PR TITLE
Add toast on copy

### DIFF
--- a/chatGPT/Components/CodeBlockView.swift
+++ b/chatGPT/Components/CodeBlockView.swift
@@ -112,6 +112,13 @@ final class CodeBlockView: UIView {
             .bind { [weak self] in
                 guard let self else { return }
                 UIPasteboard.general.string = self.codeLabel.text
+                self.copyButton.setTitle("Copied", for: .normal)
+                Observable.just(())
+                    .delay(.seconds(1), scheduler: MainScheduler.instance)
+                    .bind { [weak self] in
+                        self?.copyButton.setTitle("Copy", for: .normal)
+                    }
+                    .disposed(by: self.disposeBag)
             }
             .disposed(by: disposeBag)
 


### PR DESCRIPTION
## Summary
- show toast when code block copy button is tapped

## Testing
- `swift test -c release` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_6874bbeb4a4c832b961c39eb4b474afa