### PR TITLE
Update image group layout

### DIFF
--- a/chatGPT/Components/RemoteImageGroupAttachment.swift
+++ b/chatGPT/Components/RemoteImageGroupAttachment.swift
@@ -15,6 +15,6 @@ final class RemoteImageGroupAttachment: NSTextAttachment {
     }
 
     override func attachmentBounds(for textContainer: NSTextContainer?, proposedLineFragment lineFrag: CGRect, glyphPosition position: CGPoint, characterIndex charIndex: Int) -> CGRect {
-        CGRect(x: 0, y: 0, width: lineFrag.width, height: 200)
+        CGRect(x: 0, y: 0, width: lineFrag.width, height: lineFrag.width * 0.65)
     }
 }

--- a/chatGPT/Components/RemoteImageGroupView.swift
+++ b/chatGPT/Components/RemoteImageGroupView.swift
@@ -21,7 +21,7 @@ final class RemoteImageGroupView: UIView {
     }
 
     private func layout() {
-        backgroundColor = ThemeColor.background2
+        backgroundColor = ThemeColor.background1
         addSubview(scrollView)
         scrollView.addSubview(stackView)
         scrollView.showsHorizontalScrollIndicator = true
@@ -30,18 +30,19 @@ final class RemoteImageGroupView: UIView {
 
         scrollView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
-            make.height.equalTo(200)
         }
 
         stackView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
         }
 
+        let itemWidthRatio: CGFloat = 0.65
         urls.forEach { url in
             let imageView = RemoteImageView(url: url)
             stackView.addArrangedSubview(imageView)
             imageView.snp.makeConstraints { make in
-                make.size.equalTo(CGSize(width: 200, height: 200))
+                make.width.equalTo(self.snp.width).multipliedBy(itemWidthRatio)
+                make.height.equalTo(imageView.snp.width)
             }
         }
     }
@@ -51,6 +52,6 @@ final class RemoteImageGroupView: UIView {
     }
 
     override var intrinsicContentSize: CGSize {
-        CGSize(width: UIView.noIntrinsicMetric, height: 200)
+        CGSize(width: UIView.noIntrinsicMetric, height: UIView.noIntrinsicMetric)
     }
 }

--- a/chatGPT/Components/RemoteImageView.swift
+++ b/chatGPT/Components/RemoteImageView.swift
@@ -22,6 +22,8 @@ final class RemoteImageView: UIView {
 
     private func layout() {
         backgroundColor = ThemeColor.background2
+        layer.cornerRadius = 8
+        clipsToBounds = true
         addSubview(imageView)
         imageView.contentMode = .scaleAspectFit
         imageView.snp.makeConstraints { make in

--- a/chatGPT/Presentation/Scene/Cells/ChatMessageCell.swift
+++ b/chatGPT/Presentation/Scene/Cells/ChatMessageCell.swift
@@ -146,8 +146,8 @@ final class ChatMessageCell: UITableViewCell {
                 }
                 stackView.addArrangedSubview(attachment.view)
                 attachment.view.snp.makeConstraints { make in
-                    make.height.equalTo(200)
                     make.width.equalToSuperview()
+                    make.height.equalTo(attachment.view.snp.width).multipliedBy(0.65)
                 }
                 currentLocation = range.location + range.length
             }


### PR DESCRIPTION
## Summary
- tweak RemoteImageView corner radius
- update RemoteImageGroupView size constraints
- adjust RemoteImageGroupAttachment bounds
- update ChatMessageCell layout for image group

## Testing
- `swift test list | head` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_68751f081a94832bba4bfeea607c79d8