### PR TITLE
update model sync logic

### DIFF
--- a/chatGPT/Data/FirestoreModelConfigRepository.swift
+++ b/chatGPT/Data/FirestoreModelConfigRepository.swift
@@ -15,16 +15,128 @@ final class FirestoreModelConfigRepository: ModelConfigRepository {
                               let model = data["model"] as? String,
                               let desc = data["description"] as? String,
                               let vision = data["vision"] as? Bool else { return nil }
+                        let enable = data["enable"] as? Bool ?? false
+                        let deprecated = data["deprecated"] as? Bool ?? false
                         return ModelConfig(displayName: name,
                                            modelId: model,
                                            description: desc,
-                                           vision: vision)
+                                           vision: vision,
+                                           enable: enable,
+                                           deprecated: deprecated)
                     }
                     single(.success(configs))
                 } else if let error = error {
                     single(.failure(error))
                 } else {
                     single(.success([]))
+                }
+            }
+            return Disposables.create()
+        }
+    }
+
+    func syncConfigs(with models: [OpenAIModel]) -> Single<[ModelConfig]> {
+        Single.create { single in
+            let collection = self.db.collection("models")
+            collection.getDocuments { snapshot, error in
+                if let error = error { single(.failure(error)); return }
+
+                let docs = snapshot?.documents ?? []
+                var configs: [String: ModelConfig] = [:]
+                var references: [String: DocumentReference] = [:]
+
+                docs.forEach { doc in
+                    let data = doc.data()
+                    guard let name = data["name"] as? String,
+                          let model = data["model"] as? String,
+                          let desc = data["description"] as? String,
+                          let vision = data["vision"] as? Bool else { return }
+                    let enable = data["enable"] as? Bool ?? false
+                    let deprecated = data["deprecated"] as? Bool ?? false
+                    let config = ModelConfig(displayName: name,
+                                             modelId: model,
+                                             description: desc,
+                                             vision: vision,
+                                             enable: enable,
+                                             deprecated: deprecated)
+                    configs[model] = config
+                    references[model] = doc.reference
+                }
+
+                let availableSet = Set(models.map { $0.id })
+                var operations: [(DocumentReference, [String: Any], Bool)] = [] // bool indicates new doc
+
+                models.forEach { model in
+                    if let existing = configs[model.id] {
+                        if existing.deprecated {
+                            operations.append((references[model.id]!, ["deprecated": false], false))
+                            configs[model.id] = ModelConfig(displayName: existing.displayName,
+                                                           modelId: existing.modelId,
+                                                           description: existing.description,
+                                                           vision: existing.vision,
+                                                           enable: existing.enable,
+                                                           deprecated: false)
+                        }
+                    } else {
+                        let data: [String: Any] = [
+                            "name": model.id,
+                            "model": model.id,
+                            "description": "",
+                            "vision": false,
+                            "enable": false,
+                            "deprecated": false
+                        ]
+                        let ref = collection.document(model.id)
+                        operations.append((ref, data, true))
+                        configs[model.id] = ModelConfig(displayName: model.id,
+                                                        modelId: model.id,
+                                                        description: "",
+                                                        vision: false,
+                                                        enable: false,
+                                                        deprecated: false)
+                    }
+                }
+
+                configs.keys.forEach { key in
+                    if !availableSet.contains(key) {
+                        if let existing = configs[key], !existing.deprecated {
+                            if let ref = references[key] {
+                                operations.append((ref, ["deprecated": true], false))
+                                configs[key] = ModelConfig(displayName: existing.displayName,
+                                                            modelId: existing.modelId,
+                                                            description: existing.description,
+                                                            vision: existing.vision,
+                                                            enable: existing.enable,
+                                                            deprecated: true)
+                            }
+                        }
+                    }
+                }
+
+                let group = DispatchGroup()
+                var firstError: Error?
+                operations.forEach { ref, data, isNew in
+                    group.enter()
+                    if isNew {
+                        ref.setData(data) { err in
+                            if let err = err { firstError = err }
+                            group.leave()
+                        }
+                    } else {
+                        ref.setData(data, merge: true) { err in
+                            if let err = err { firstError = err }
+                            group.leave()
+                        }
+                    }
+                }
+
+                group.notify(queue: .main) {
+                    if let error = firstError {
+                        single(.failure(error))
+                    } else {
+                        let result = configs.values.filter { $0.enable && !$0.deprecated }
+                        single(.success(Array(result)))
+                    }
                 }
             }
             return Disposables.create()

--- a/chatGPT/Domain/Entity/ModelConfig.swift
+++ b/chatGPT/Domain/Entity/ModelConfig.swift
@@ -5,12 +5,26 @@ struct ModelConfig: Decodable {
     let modelId: String
     let description: String
     let vision: Bool
+    let enable: Bool
+    let deprecated: Bool
 
     enum CodingKeys: String, CodingKey {
         case displayName = "name"
         case modelId = "model"
         case description
         case vision
+        case enable
+        case deprecated
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        displayName = try container.decode(String.self, forKey: .displayName)
+        modelId = try container.decode(String.self, forKey: .modelId)
+        description = try container.decodeIfPresent(String.self, forKey: .description) ?? ""
+        vision = try container.decodeIfPresent(Bool.self, forKey: .vision) ?? false
+        enable = try container.decodeIfPresent(Bool.self, forKey: .enable) ?? false
+        deprecated = try container.decodeIfPresent(Bool.self, forKey: .deprecated) ?? false
     }
 
     var openAIModel: OpenAIModel {

--- a/chatGPT/Domain/Repository/ModelConfigRepository.swift
+++ b/chatGPT/Domain/Repository/ModelConfigRepository.swift
@@ -3,4 +3,5 @@ import RxSwift
 
 protocol ModelConfigRepository {
     func fetchConfigs() -> Single<[ModelConfig]>
+    func syncConfigs(with models: [OpenAIModel]) -> Single<[ModelConfig]>
 }

--- a/chatGPT/Domain/UseCase/FetchModelConfigsUseCase.swift
+++ b/chatGPT/Domain/UseCase/FetchModelConfigsUseCase.swift
@@ -12,14 +12,10 @@ final class FetchModelConfigsUseCase {
     }
 
     func execute() -> Single<[ModelConfig]> {
-        configRepository.fetchConfigs()
-            .flatMap { [weak self] configs -> Single<[ModelConfig]> in
-                guard let self else { return .just(configs) }
-                return Self.wrap(self.openAIRepository)
-                    .map { available in
-                        let set = Set(available.map { $0.id })
-                        return configs.filter { set.contains($0.modelId) }
-                    }
+        Self.wrap(openAIRepository)
+            .flatMap { [weak self] available -> Single<[ModelConfig]> in
+                guard let self else { return .just([]) }
+                return self.configRepository.syncConfigs(with: available)
             }
     }
 


### PR DESCRIPTION
## Summary
- add enable/deprecated fields to ModelConfig
- support syncing available models with Firestore
- expose syncConfigs in ModelConfigRepository
- update FetchModelConfigsUseCase to use sync logic

## Testing
- `swift test` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_68764fd96cdc832b9f73cd8a9ade72e2