### PR TITLE
Improve model sync

### DIFF
--- a/chatGPT/Data/FirestoreModelConfigRepository.swift
+++ b/chatGPT/Data/FirestoreModelConfigRepository.swift
@@ -15,16 +15,103 @@ final class FirestoreModelConfigRepository: ModelConfigRepository {
                               let model = data["model"] as? String,
                               let desc = data["description"] as? String,
                               let vision = data["vision"] as? Bool else { return nil }
+                        let enable = data["enable"] as? Bool ?? false
                         return ModelConfig(displayName: name,
                                            modelId: model,
                                            description: desc,
-                                           vision: vision)
+                                           vision: vision,
+                                           enabled: enable)
                     }
                     single(.success(configs))
                 } else if let error = error {
                     single(.failure(error))
                 } else {
                     single(.success([]))
+                }
+            }
+            return Disposables.create()
+        }
+    }
+
+    func syncModels(with available: [OpenAIModel]) -> Single<[ModelConfig]> {
+        Single.create { single in
+            let collection = self.db.collection("models")
+            collection.getDocuments { snapshot, error in
+                guard let docs = snapshot?.documents, error == nil else {
+                    if let error = error {
+                        single(.failure(error))
+                    } else {
+                        single(.success([]))
+                    }
+                    return
+                }
+
+                let availableSet = Set(available.map { $0.id })
+                var existing: [String: QueryDocumentSnapshot] = [:]
+                docs.forEach { doc in
+                    if let id = doc.data()["model"] as? String {
+                        existing[id] = doc
+                    }
+                }
+
+                let group = DispatchGroup()
+                var firstError: Error?
+
+                available.forEach { model in
+                    if existing[model.id] == nil {
+                        group.enter()
+                        let data: [String: Any] = [
+                            "name": model.id,
+                            "model": model.id,
+                            "description": "",
+                            "vision": false,
+                            "enable": false
+                        ]
+                        collection.document(model.id).setData(data) { err in
+                            if let err = err { firstError = err }
+                            group.leave()
+                        }
+                    }
+                }
+
+                for doc in docs {
+                    guard let id = doc.data()["model"] as? String else { continue }
+                    let enabled = doc.data()["enable"] as? Bool ?? false
+                    if enabled && !availableSet.contains(id) {
+                        group.enter()
+                        collection.document(doc.documentID).updateData(["enable": false]) { err in
+                            if let err = err { firstError = err }
+                            group.leave()
+                        }
+                    }
+                }
+
+                group.notify(queue: .main) {
+                    if let err = firstError {
+                        single(.failure(err))
+                        return
+                    }
+                    collection.whereField("enable", isEqualTo: true).getDocuments { snap, err in
+                        if let err = err {
+                            single(.failure(err))
+                        } else if let docs = snap?.documents {
+                            let configs: [ModelConfig] = docs.compactMap { doc in
+                                let data = doc.data()
+                                guard let name = data["name"] as? String,
+                                      let model = data["model"] as? String,
+                                      let desc = data["description"] as? String,
+                                      let vision = data["vision"] as? Bool else { return nil }
+                                return ModelConfig(displayName: name,
+                                                   modelId: model,
+                                                   description: desc,
+                                                   vision: vision,
+                                                   enabled: true)
+                            }
+                            single(.success(configs))
+                        } else {
+                            single(.success([]))
+                        }
+                    }
                 }
             }
             return Disposables.create()

--- a/chatGPT/Domain/Entity/ModelConfig.swift
+++ b/chatGPT/Domain/Entity/ModelConfig.swift
@@ -5,12 +5,14 @@ struct ModelConfig: Decodable {
     let modelId: String
     let description: String
     let vision: Bool
+    let enabled: Bool
 
     enum CodingKeys: String, CodingKey {
         case displayName = "name"
         case modelId = "model"
         case description
         case vision
+        case enabled = "enable"
     }
 
     var openAIModel: OpenAIModel {

--- a/chatGPT/Domain/Repository/ModelConfigRepository.swift
+++ b/chatGPT/Domain/Repository/ModelConfigRepository.swift
@@ -3,4 +3,5 @@ import RxSwift
 
 protocol ModelConfigRepository {
     func fetchConfigs() -> Single<[ModelConfig]>
+    func syncModels(with available: [OpenAIModel]) -> Single<[ModelConfig]>
 }

--- a/chatGPT/Domain/UseCase/FetchModelConfigsUseCase.swift
+++ b/chatGPT/Domain/UseCase/FetchModelConfigsUseCase.swift
@@ -12,14 +12,10 @@ final class FetchModelConfigsUseCase {
     }
 
     func execute() -> Single<[ModelConfig]> {
-        configRepository.fetchConfigs()
-            .flatMap { [weak self] configs -> Single<[ModelConfig]> in
-                guard let self else { return .just(configs) }
-                return Self.wrap(self.openAIRepository)
-                    .map { available in
-                        let set = Set(available.map { $0.id })
-                        return configs.filter { set.contains($0.modelId) }
-                    }
+        Self.wrap(openAIRepository)
+            .flatMap { [weak self] models -> Single<[ModelConfig]> in
+                guard let self else { return .just([]) }
+                return self.configRepository.syncModels(with: models)
             }
     }
 


### PR DESCRIPTION
## Summary
- keep enabled flag in `ModelConfig`
- add sync API to `ModelConfigRepository`
- sync models via Firestore and OpenAI
- return enabled configs only

## Testing
- `swift build -c debug` *(fails: no such module 'UIKit')*
- `swift test` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_687780f9c298832b80b6a2df3fcae990