### PR TITLE
Add models rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,3 +154,4 @@ func execute(prompt: String, model: OpenAIModel, completion: @escaping (Result<S
 
 Firestore에 저장되는 `preferences`와 `conversations` 컬렉션은 인증된 사용자만 접근할 수 있도록 권한을 설정해야 합니다.
 Firebase 콘솔의 **Firestore Database > 규칙** 탭에서 [`firebase/firestore_rules.md`](firebase/firestore_rules.md) 파일의 내용을 적용하세요.
+또한 `/models` 컬렉션에 대한 규칙도 동일하게 설정해야 합니다.

--- a/firebase/firestore_rules.md
+++ b/firebase/firestore_rules.md
@@ -15,6 +15,12 @@ service cloud.firestore {
     match /conversations/{userId}/items/{conversationId} {
       allow read, write: if request.auth != null && request.auth.uid == userId;
     }
+
+    // models 컬렉션
+    match /models/{modelId} {
+      allow read: if true;
+      allow write: if request.auth != null;
+    }
   }
 }
 ```


### PR DESCRIPTION
## Summary
- update Firestore rules for `/models`
- mention `/models` rule in README

## Testing
- `swift test -c release` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_68778329b088832b969b93144a364261