### PR TITLE
Change plus icons and permission alert

### DIFF
--- a/chatGPT/Components/ChatComposerView.swift
+++ b/chatGPT/Components/ChatComposerView.swift
@@ -31,7 +31,7 @@ final class ChatComposerView: UIView, UITextViewDelegate {
 
     private let plusButton: UIButton = {
         let button = UIButton(type: .system)
-        button.setImage(UIImage(systemName: "plus.circle"), for: .normal)
+        button.setImage(UIImage(systemName: "plus"), for: .normal)
         button.tintColor = ThemeColor.tintDark
         return button
     }()

--- a/chatGPT/Presentation/Scene/MainViewController.swift
+++ b/chatGPT/Presentation/Scene/MainViewController.swift
@@ -51,7 +51,7 @@ final class MainViewController: UIViewController {
     
     // MARK: 새 대화 버튼
     private lazy var newChatButton: UIBarButtonItem = {
-        let button = UIBarButtonItem(barButtonSystemItem: .add, target: nil, action: nil)
+        let button = UIBarButtonItem(image: UIImage(systemName: "plus"), style: .plain, target: nil, action: nil)
         return button
     }()
     
@@ -351,8 +351,6 @@ final class MainViewController: UIViewController {
                 DispatchQueue.main.async {
                     if newStatus == .authorized || newStatus == .limited {
                         self?.presentPhotoPicker()
-                    } else {
-                        self?.presentPermissionAlert()
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- update Plus button icons in Main and composer views
- show permission alert only when tapping plus after denial

## Testing
- `swift test -c debug` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_6877a85937c8832ba97667cd95c4f644