### PR TITLE
add image delete in composer

### DIFF
--- a/chatGPT/Components/ChatComposerImageCell.swift
+++ b/chatGPT/Components/ChatComposerImageCell.swift
@@ -1,8 +1,15 @@
 import UIKit
 import SnapKit
 
+import RxSwift
+import RxCocoa
+
 final class ChatComposerImageCell: UICollectionViewCell {
     private let imageView = UIImageView()
+    private let closeButton = UIButton(type: .system)
+    private var disposeBag = DisposeBag()
+
+    var removeHandler: (() -> Void)?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -14,8 +21,13 @@ final class ChatComposerImageCell: UICollectionViewCell {
         layout()
     }
 
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        disposeBag = DisposeBag()
+    }
+
     private func layout() {
-        contentView.addSubview(imageView)
+        [imageView, closeButton].forEach(contentView.addSubview)
         imageView.contentMode = .scaleAspectFill
         imageView.clipsToBounds = true
         imageView.layer.cornerRadius = 8
@@ -23,9 +35,25 @@ final class ChatComposerImageCell: UICollectionViewCell {
             make.edges.equalToSuperview()
             make.width.equalTo(imageView.snp.height)
         }
+
+        let config = UIImage.SymbolConfiguration(pointSize: 10, weight: .bold)
+        closeButton.setImage(UIImage(systemName: "xmark", withConfiguration: config), for: .normal)
+        closeButton.tintColor = .white
+        closeButton.backgroundColor = .black
+        closeButton.layer.cornerRadius = 10
+        closeButton.snp.makeConstraints { make in
+            make.top.trailing.equalToSuperview().inset(2)
+            make.width.height.equalTo(20)
+        }
     }
 
-    func configure(image: UIImage) {
+    func configure(image: UIImage, onDelete: @escaping () -> Void) {
         imageView.image = image
+        removeHandler = onDelete
+        closeButton.rx.tap
+            .bind { [weak self] in
+                self?.removeHandler?()
+            }
+            .disposed(by: disposeBag)
     }
 }

--- a/chatGPT/Components/ChatComposerView.swift
+++ b/chatGPT/Components/ChatComposerView.swift
@@ -227,8 +227,10 @@ final class ChatComposerView: UIView, UITextViewDelegate {
             .disposed(by: disposeBag)
 
         selectedImages
-            .bind(to: imageCollectionView.rx.items(cellIdentifier: "ChatComposerImageCell", cellType: ChatComposerImageCell.self)) { index, image, cell in
-                cell.configure(image: image)
+            .bind(to: imageCollectionView.rx.items(cellIdentifier: "ChatComposerImageCell", cellType: ChatComposerImageCell.self)) { [weak self] index, image, cell in
+                cell.configure(image: image) { [weak self] in
+                    self?.removeSelectedImage(at: index)
+                }
             }
             .disposed(by: disposeBag)
 
@@ -263,5 +265,12 @@ final class ChatComposerView: UIView, UITextViewDelegate {
     func textViewDidChange(_ textView: UITextView) {
         updatePlaceholderVisibility()
         adjustTextViewHeight()
+    }
+
+    private func removeSelectedImage(at index: Int) {
+        var images = selectedImages.value
+        guard images.indices.contains(index) else { return }
+        images.remove(at: index)
+        selectedImages.accept(images)
     }
 }


### PR DESCRIPTION
## Summary
- add close button to `ChatComposerImageCell`
- enable deleting selected images in `ChatComposerView`

## Testing
- `swift test -c debug` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_6877c0bf7ebc832bb225b915e1636c99