### PR TITLE
feature/add-plus-menu

### DIFF
--- a/chatGPT/Components/ChatComposerView.swift
+++ b/chatGPT/Components/ChatComposerView.swift
@@ -57,6 +57,14 @@ final class ChatComposerView: UIView, UITextViewDelegate {
     var onSendButtonTapped: ((String) -> Void)?
     var onPlusButtonTapped: (() -> Void)?
 
+    var plusButtonMenu: UIMenu? {
+        get { plusButton.menu }
+        set {
+            plusButton.menu = newValue
+            plusButton.showsMenuAsPrimaryAction = newValue != nil
+        }
+    }
+
     var plusButtonEnabled: Bool = false {
         didSet {
             plusButton.isEnabled = plusButtonEnabled
@@ -222,7 +230,10 @@ final class ChatComposerView: UIView, UITextViewDelegate {
 
         self.plusButton.rx.tap
             .bind { [weak self] in
-                self?.onPlusButtonTapped?()
+                guard let self else { return }
+                if self.plusButton.menu == nil {
+                    self.onPlusButtonTapped?()
+                }
             }
             .disposed(by: disposeBag)
 


### PR DESCRIPTION
## Summary
- show camera, album and file picker via UIMenu
- expose menu API from ChatComposerView
- handle image picking for camera and album

## Testing
- `swift test -l` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_6878cc48e480832b9ff065c13441d5be