### PR TITLE
Add vision chat support

### DIFF
--- a/chatGPT/Data/OpenAIRepository.swift
+++ b/chatGPT/Data/OpenAIRepository.swift
@@ -6,10 +6,11 @@
 //
 
 import Foundation
+import UIKit
 import RxSwift
 
 protocol OpenAIRepository {
     func fetchAvailableModels(completion: @escaping (Result<[OpenAIModel], Error>) -> Void)
-    func sendChat(messages: [Message], model: OpenAIModel, stream: Bool, completion: @escaping (Result<String, Error>) -> Void)
-    func sendChatStream(messages: [Message], model: OpenAIModel) -> Observable<String>
+    func sendChat(messages: [Message], images: [UIImage], model: OpenAIModel, stream: Bool, completion: @escaping (Result<String, Error>) -> Void)
+    func sendChatStream(messages: [Message], images: [UIImage], model: OpenAIModel) -> Observable<String>
 }

--- a/chatGPT/Data/OpenAIRepositoryImpl.swift
+++ b/chatGPT/Data/OpenAIRepositoryImpl.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UIKit
 import RxSwift
 
 final class OpenAIRepositoryImpl: OpenAIRepository {
@@ -16,8 +17,15 @@ final class OpenAIRepositoryImpl: OpenAIRepository {
     }
     
     /// 채팅전송
-    func sendChat(messages: [Message], model: OpenAIModel, stream: Bool, completion: @escaping (Result<String, Error>) -> Void) {
-        service.request(.chat(messages: messages, model: model, stream: stream)) { (result: Result<OpenAIResponse, Error>) in
+    func sendChat(messages: [Message], images: [UIImage], model: OpenAIModel, stream: Bool, completion: @escaping (Result<String, Error>) -> Void) {
+        let endpoint: OpenAIEndpoint
+        if images.isEmpty {
+            endpoint = .chat(messages: messages, model: model, stream: stream)
+        } else {
+            let datas = images.compactMap { $0.pngData() }
+            endpoint = .vision(messages: messages, imageDatas: datas, model: model, stream: stream)
+        }
+        service.request(endpoint) { (result: Result<OpenAIResponse, Error>) in
             switch result {
             case .success(let decoded):
                 let reply = decoded.choices.first?.message.content ?? ""
@@ -28,8 +36,13 @@ final class OpenAIRepositoryImpl: OpenAIRepository {
         }
     }
 
-    func sendChatStream(messages: [Message], model: OpenAIModel) -> Observable<String> {
-        service.requestStream(.chat(messages: messages, model: model, stream: true))
+    func sendChatStream(messages: [Message], images: [UIImage], model: OpenAIModel) -> Observable<String> {
+        if images.isEmpty {
+            return service.requestStream(.chat(messages: messages, model: model, stream: true))
+        } else {
+            let datas = images.compactMap { $0.pngData() }
+            return service.requestStream(.vision(messages: messages, imageDatas: datas, model: model, stream: true))
+        }
     }
     
     /// 사용가능한 모델 조회

--- a/chatGPT/Domain/Entity/OpenAIVisionChatRequest.swift
+++ b/chatGPT/Domain/Entity/OpenAIVisionChatRequest.swift
@@ -1,0 +1,27 @@
+//
+//  OpenAIVisionChatRequest.swift
+//  chatGPT
+//
+//  Created by Codex on 2024.
+//
+
+import Foundation
+
+struct OpenAIVisionChatRequest: Encodable {
+    struct VisionMessage: Encodable {
+        struct VisionContent: Encodable {
+            let type: String
+            let text: String?
+            let image_url: ImageURL?
+        }
+        struct ImageURL: Encodable {
+            let url: String
+        }
+        let role: RoleType
+        let content: [VisionContent]
+    }
+    let model: String
+    let messages: [VisionMessage]
+    let temperature: Double
+    let stream: Bool
+}

--- a/chatGPT/Domain/UseCase/SendChatMessageUseCase.swift
+++ b/chatGPT/Domain/UseCase/SendChatMessageUseCase.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UIKit
 
 final class SendChatMessageUseCase {
     private let repository: OpenAIRepository
@@ -14,7 +15,7 @@ final class SendChatMessageUseCase {
         self.repository = repository
     }
 
-    func execute(messages: [Message], model: OpenAIModel, stream: Bool, completion: @escaping (Result<String, Error>) -> Void) {
-        repository.sendChat(messages: messages, model: model, stream: stream, completion: completion)
+    func execute(messages: [Message], images: [UIImage], model: OpenAIModel, stream: Bool, completion: @escaping (Result<String, Error>) -> Void) {
+        repository.sendChat(messages: messages, images: images, model: model, stream: stream, completion: completion)
     }
 }

--- a/chatGPT/Domain/UseCase/SendChatWithContextUseCase.swift
+++ b/chatGPT/Domain/UseCase/SendChatWithContextUseCase.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UIKit
 import RxSwift
 
 final class SendChatWithContextUseCase {
@@ -28,6 +29,7 @@ final class SendChatWithContextUseCase {
     }
 
     func execute(prompt: String,
+                 images: [UIImage],
                  model: OpenAIModel,
                  stream: Bool,
                  preference: String?,
@@ -42,7 +44,7 @@ final class SendChatWithContextUseCase {
         messages += contextRepository.messages
         messages.append(Message(role: .user, content: prompt))
 
-        openAIRepository.sendChat(messages: messages, model: model, stream: stream) { [weak self] result in
+        openAIRepository.sendChat(messages: messages, images: images, model: model, stream: stream) { [weak self] result in
             guard let self = self else { return }
             switch result {
             case .success(let reply):
@@ -57,7 +59,7 @@ final class SendChatWithContextUseCase {
         }
     }
 
-    func stream(prompt: String, model: OpenAIModel, preference: String?) -> Observable<String> {
+    func stream(prompt: String, images: [UIImage], model: OpenAIModel, preference: String?) -> Observable<String> {
         var messages = [Message]()
         if let preference {
             messages.append(Message(role: .system, content: preference))
@@ -68,7 +70,7 @@ final class SendChatWithContextUseCase {
         messages += contextRepository.messages
         messages.append(Message(role: .user, content: prompt))
 
-        return openAIRepository.sendChatStream(messages: messages, model: model)
+        return openAIRepository.sendChatStream(messages: messages, images: images, model: model)
     }
 
     func finalize(prompt: String, reply: String, model: OpenAIModel) {

--- a/chatGPT/Presentation/Scene/ChatViewModel.swift
+++ b/chatGPT/Presentation/Scene/ChatViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UIKit
 import RxSwift
 import RxRelay
 
@@ -72,6 +73,10 @@ final class ChatViewModel {
     }
     
     func send(prompt: String, model: OpenAIModel, stream: Bool) {
+        send(prompt: prompt, images: [], model: model, stream: stream)
+    }
+
+    func send(prompt: String, images: [UIImage], model: OpenAIModel, stream: Bool) {
         let isFirst = messages.value.isEmpty
         appendMessage(ChatMessage(type: .user, text: prompt))
 
@@ -91,6 +96,7 @@ final class ChatViewModel {
             .catchAndReturn(nil)
             .subscribe(onSuccess: { [weak self] preference in
                 self?.sendInternal(prompt: prompt,
+                                   images: images,
                                    model: model,
                                    stream: stream,
                                    preference: preference,
@@ -100,6 +106,7 @@ final class ChatViewModel {
     }
 
     private func sendInternal(prompt: String,
+                              images: [UIImage],
                               model: OpenAIModel,
                               stream: Bool,
                               preference: UserPreference?,
@@ -107,6 +114,7 @@ final class ChatViewModel {
         guard stream else {
             let prefMessage = self.preferenceText(from: preference)
             sendMessageUseCase.execute(prompt: prompt,
+                                      images: images,
                                       model: model,
                                       stream: false,
                                       preference: prefMessage) { [weak self] result in
@@ -137,7 +145,7 @@ final class ChatViewModel {
         var fullText = ""
 
         let prefMessage = self.preferenceText(from: preference)
-        sendMessageUseCase.stream(prompt: prompt, model: model, preference: prefMessage)
+        sendMessageUseCase.stream(prompt: prompt, images: images, model: model, preference: prefMessage)
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] chunk in
                 guard let self else { return }

--- a/chatGPT/Presentation/Scene/MainViewController.swift
+++ b/chatGPT/Presentation/Scene/MainViewController.swift
@@ -230,9 +230,12 @@ final class MainViewController: UIViewController {
         // MARK: ChatComposerView 전송버튼 클로져
         self.composerView.onSendButtonTapped = { [weak self] text in
             guard let self = self else { return }
+            let images = self.composerView.selectedImages.value
             self.chatViewModel.send(prompt: text,
+                                    images: images,
                                     model: self.selectedModel,
                                     stream: self.streamEnabled)
+            self.composerView.selectedImages.accept([])
         }
         self.composerView.onPlusButtonTapped = { [weak self] in
             self?.handleAlbumOption()

--- a/chatGPT/Service/OpenAIEndPoint.swift
+++ b/chatGPT/Service/OpenAIEndPoint.swift
@@ -17,6 +17,15 @@ enum OpenAIEndpoint {
         stream: Bool = false,
         temperature: Double = 0.7
     )
+
+    /// Vision 모델 질문요청
+    case vision(
+        messages: [Message],
+        imageDatas: [Data],
+        model: OpenAIModel,
+        stream: Bool = false,
+        temperature: Double = 0.7
+    )
     
     /// 사용가능모델
     case models
@@ -25,7 +34,9 @@ enum OpenAIEndpoint {
         switch self {
         case .chat:
             return "/chat/completions"
-            
+        case .vision:
+            return "/chat/completions"
+
         case .models:
             return "/models"
         }
@@ -34,6 +45,8 @@ enum OpenAIEndpoint {
     var method: HTTPMethod {
         switch self {
         case .chat:
+            return .post
+        case .vision:
             return .post
         case .models:
             return .get
@@ -46,12 +59,32 @@ enum OpenAIEndpoint {
         ]
     }
     
-    var encodableBody: OpenAIChatRequest? {
+    var encodableBody: Encodable? {
         switch self {
         case .chat(let messages, let model, let stream, let temp):
             return OpenAIChatRequest(
                 model: model.id,
                 messages: messages,
+                temperature: temp,
+                stream: stream
+            )
+        case .vision(let messages, let imageDatas, let model, let stream, let temp):
+            let images = imageDatas.map { "data:image/png;base64,\($0.base64EncodedString())" }
+            let visMessages: [OpenAIVisionChatRequest.VisionMessage] = messages.map {
+                let content = [OpenAIVisionChatRequest.VisionMessage.VisionContent(type: "text", text: $0.content, image_url: nil)]
+                return OpenAIVisionChatRequest.VisionMessage(role: $0.role, content: content)
+            }
+            let userContents = [
+                OpenAIVisionChatRequest.VisionMessage.VisionContent(type: "text", text: messages.last?.content ?? "", image_url: nil)
+            ] + images.map {
+                OpenAIVisionChatRequest.VisionMessage.VisionContent(type: "image_url", text: nil, image_url: .init(url: $0))
+            }
+            var final = visMessages
+            if !final.isEmpty { final.removeLast() }
+            final.append(OpenAIVisionChatRequest.VisionMessage(role: .user, content: userContents))
+            return OpenAIVisionChatRequest(
+                model: model.id,
+                messages: final,
                 temperature: temp,
                 stream: stream
             )


### PR DESCRIPTION
## Summary
- support images in ChatViewModel
- update SendChatWithContextUseCase and repository for vision chat
- encode images via new OpenAIEndpoint case
- pass selected images from MainViewController

## Testing
- `swift test -v` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_6878d1100cac832ba854bc8050852f7f