### PR TITLE
Add detail for vision images

### DIFF
--- a/chatGPT/Domain/Entity/OpenAIVisionChatRequest.swift
+++ b/chatGPT/Domain/Entity/OpenAIVisionChatRequest.swift
@@ -16,6 +16,12 @@ struct OpenAIVisionChatRequest: Encodable {
         }
         struct ImageURL: Encodable {
             let url: String
+            let detail: String?
+
+            init(url: String, detail: String? = "auto") {
+                self.url = url
+                self.detail = detail
+            }
         }
         let role: RoleType
         let content: [VisionContent]

--- a/chatGPT/Service/OpenAIEndPoint.swift
+++ b/chatGPT/Service/OpenAIEndPoint.swift
@@ -77,7 +77,11 @@ enum OpenAIEndpoint {
             let userContents = [
                 OpenAIVisionChatRequest.VisionMessage.VisionContent(type: "text", text: messages.last?.content ?? "", image_url: nil)
             ] + images.map {
-                OpenAIVisionChatRequest.VisionMessage.VisionContent(type: "image_url", text: nil, image_url: .init(url: $0))
+                OpenAIVisionChatRequest.VisionMessage.VisionContent(
+                    type: "image_url",
+                    text: nil,
+                    image_url: .init(url: $0, detail: "auto")
+                )
             }
             var final = visMessages
             if !final.isEmpty { final.removeLast() }


### PR DESCRIPTION
## Summary
- add `detail` parameter to vision image requests
- pass `detail` value when building OpenAI vision messages

## Testing
- `swift build` *(fails: no such module 'UIKit')*
- `swift test` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_6878d99bdfd0832ba055f584c3c60024