### PR TITLE
Add attachments support in chat

### DIFF
--- a/chatGPT.xcodeproj/project.pbxproj
+++ b/chatGPT.xcodeproj/project.pbxproj
@@ -26,8 +26,9 @@
 		F1051DF62E004E72008D5D80 /* OpenAIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1051DF52E004E72008D5D80 /* OpenAIService.swift */; };
 		F1051DF82E004EBB008D5D80 /* OpenAIEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1051DF72E004EBB008D5D80 /* OpenAIEndPoint.swift */; };
 		F1051DFA2E004EC9008D5D80 /* OpenAIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1051DF92E004EC8008D5D80 /* OpenAIError.swift */; };
-		F1051DFC2E0050EE008D5D80 /* OpenAIChatRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1051DFB2E0050EE008D5D80 /* OpenAIChatRequest.swift */; };
-		F117E06E2E01525100D1C95F /* OpenAIModelListResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = F117E06D2E01525100D1C95F /* OpenAIModelListResponse.swift */; };
+                F1051DFC2E0050EE008D5D80 /* OpenAIChatRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1051DFB2E0050EE008D5D80 /* OpenAIChatRequest.swift */; };
+                ABCDEF012345678900ABCDEF /* OpenAIVisionModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF012345678900ABCDE0 /* OpenAIVisionModels.swift */; };
+                F117E06E2E01525100D1C95F /* OpenAIModelListResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = F117E06D2E01525100D1C95F /* OpenAIModelListResponse.swift */; };
 		F117E0712E01587F00D1C95F /* String+Truncate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F117E0702E01587F00D1C95F /* String+Truncate.swift */; };
 		F117E0732E01847E00D1C95F /* FetchAvailableModelsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = F117E0722E01847E00D1C95F /* FetchAvailableModelsUseCase.swift */; };
 		F117E0752E0184A900D1C95F /* OpenAIRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = F117E0742E0184A900D1C95F /* OpenAIRepository.swift */; };
@@ -157,8 +158,9 @@
 		F1051DF52E004E72008D5D80 /* OpenAIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAIService.swift; sourceTree = "<group>"; };
 		F1051DF72E004EBB008D5D80 /* OpenAIEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAIEndPoint.swift; sourceTree = "<group>"; };
 		F1051DF92E004EC8008D5D80 /* OpenAIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAIError.swift; sourceTree = "<group>"; };
-		F1051DFB2E0050EE008D5D80 /* OpenAIChatRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAIChatRequest.swift; sourceTree = "<group>"; };
-		F117E06D2E01525100D1C95F /* OpenAIModelListResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAIModelListResponse.swift; sourceTree = "<group>"; };
+                F1051DFB2E0050EE008D5D80 /* OpenAIChatRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAIChatRequest.swift; sourceTree = "<group>"; };
+                ABCDEF012345678900ABCDE0 /* OpenAIVisionModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAIVisionModels.swift; sourceTree = "<group>"; };
+                F117E06D2E01525100D1C95F /* OpenAIModelListResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAIModelListResponse.swift; sourceTree = "<group>"; };
 		F117E0702E01587F00D1C95F /* String+Truncate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Truncate.swift"; sourceTree = "<group>"; };
 		F117E0722E01847E00D1C95F /* FetchAvailableModelsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchAvailableModelsUseCase.swift; sourceTree = "<group>"; };
 		F117E0742E0184A900D1C95F /* OpenAIRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAIRepository.swift; sourceTree = "<group>"; };
@@ -298,8 +300,9 @@
 				F15BC4FF2E0AC1A200F25923 /* ConversationSummary.swift */,
 				F1452D842E09741500795A9E /* AuthUser.swift */,
 				F1051DF22E004E17008D5D80 /* OpenAIResponse.swift */,
-				F1051DFB2E0050EE008D5D80 /* OpenAIChatRequest.swift */,
-				F117E06D2E01525100D1C95F /* OpenAIModelListResponse.swift */,
+                               F1051DFB2E0050EE008D5D80 /* OpenAIChatRequest.swift */,
+                                ABCDEF012345678900ABCDE0 /* OpenAIVisionModels.swift */,
+                               F117E06D2E01525100D1C95F /* OpenAIModelListResponse.swift */,
 				F1051DEF2E004CFA008D5D80 /* OpenAIModel.swift */,
 			);
 			path = Entity;
@@ -708,8 +711,9 @@
 				F15BC5002E0AC1A200F25923 /* ConversationSummary.swift in Sources */,
 				F1051DFA2E004EC9008D5D80 /* OpenAIError.swift in Sources */,
 				E1B9A0B22E00000100000000 /* RoleType.swift in Sources */,
-				F1051DFC2E0050EE008D5D80 /* OpenAIChatRequest.swift in Sources */,
-				F117E06E2E01525100D1C95F /* OpenAIModelListResponse.swift in Sources */,
+                                F1051DFC2E0050EE008D5D80 /* OpenAIChatRequest.swift in Sources */,
+                                ABCDEF012345678900ABCDEF /* OpenAIVisionModels.swift in Sources */,
+                                F117E06E2E01525100D1C95F /* OpenAIModelListResponse.swift in Sources */,
 				F117E0772E0184FF00D1C95F /* OpenAIRepositoryImpl.swift in Sources */,
 				F16D6E2F2E0D3DCA00E0718A /* UIColor+Dynamic.swift in Sources */,
 				F1EF04EF2E044EC5005D2CF9 /* UIColor+Hex.swift in Sources */,

--- a/chatGPT/Components/ChatComposerImageCell.swift
+++ b/chatGPT/Components/ChatComposerImageCell.swift
@@ -4,6 +4,11 @@ import SnapKit
 import RxSwift
 import RxCocoa
 
+enum Attachment {
+    case image(UIImage)
+    case file(URL)
+}
+
 final class ChatComposerImageCell: UICollectionViewCell {
     private let imageView = UIImageView()
     private let closeButton = UIButton(type: .system)
@@ -47,8 +52,15 @@ final class ChatComposerImageCell: UICollectionViewCell {
         }
     }
 
-    func configure(image: UIImage, onDelete: @escaping () -> Void) {
-        imageView.image = image
+    func configure(attachment: Attachment, onDelete: @escaping () -> Void) {
+        switch attachment {
+        case .image(let image):
+            imageView.image = image
+            imageView.contentMode = .scaleAspectFill
+        case .file:
+            imageView.image = UIImage(systemName: "doc.fill")
+            imageView.contentMode = .scaleAspectFit
+        }
         removeHandler = onDelete
         closeButton.rx.tap
             .bind { [weak self] in

--- a/chatGPT/Data/OpenAIRepository.swift
+++ b/chatGPT/Data/OpenAIRepository.swift
@@ -12,4 +12,6 @@ protocol OpenAIRepository {
     func fetchAvailableModels(completion: @escaping (Result<[OpenAIModel], Error>) -> Void)
     func sendChat(messages: [Message], model: OpenAIModel, stream: Bool, completion: @escaping (Result<String, Error>) -> Void)
     func sendChatStream(messages: [Message], model: OpenAIModel) -> Observable<String>
+    func sendVision(messages: [VisionMessage], model: OpenAIModel, stream: Bool, completion: @escaping (Result<String, Error>) -> Void)
+    func sendVisionStream(messages: [VisionMessage], model: OpenAIModel) -> Observable<String>
 }

--- a/chatGPT/Data/OpenAIRepositoryImpl.swift
+++ b/chatGPT/Data/OpenAIRepositoryImpl.swift
@@ -31,6 +31,22 @@ final class OpenAIRepositoryImpl: OpenAIRepository {
     func sendChatStream(messages: [Message], model: OpenAIModel) -> Observable<String> {
         service.requestStream(.chat(messages: messages, model: model, stream: true))
     }
+
+    func sendVision(messages: [VisionMessage], model: OpenAIModel, stream: Bool, completion: @escaping (Result<String, Error>) -> Void) {
+        service.request(.vision(messages: messages, model: model, stream: stream)) { (result: Result<OpenAIResponse, Error>) in
+            switch result {
+            case .success(let decoded):
+                let reply = decoded.choices.first?.message.content ?? ""
+                completion(.success(reply))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+
+    func sendVisionStream(messages: [VisionMessage], model: OpenAIModel) -> Observable<String> {
+        service.requestStream(.vision(messages: messages, model: model, stream: true))
+    }
     
     /// 사용가능한 모델 조회
     func fetchAvailableModels(completion: @escaping (Result<[OpenAIModel], Error>) -> Void) {

--- a/chatGPT/Domain/Entity/OpenAIVisionModels.swift
+++ b/chatGPT/Domain/Entity/OpenAIVisionModels.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+struct VisionContent: Encodable {
+    let type: String
+    let text: String?
+    let imageURL: String?
+
+    enum CodingKeys: String, CodingKey {
+        case type, text
+        case imageURL = "image_url"
+    }
+}
+
+struct VisionMessage: Encodable {
+    let role: RoleType
+    let content: [VisionContent]
+}
+
+struct OpenAIVisionChatRequest: Encodable {
+    let model: String
+    let messages: [VisionMessage]
+    let temperature: Double
+    let stream: Bool
+}

--- a/chatGPT/Presentation/Scene/MainViewController.swift
+++ b/chatGPT/Presentation/Scene/MainViewController.swift
@@ -228,9 +228,11 @@ final class MainViewController: UIViewController {
         
         
         // MARK: ChatComposerView 전송버튼 클로져
-        self.composerView.onSendButtonTapped = { [weak self] text in
+        self.composerView.onSendButtonTapped = { [weak self] text, images, files in
             guard let self = self else { return }
             self.chatViewModel.send(prompt: text,
+                                    images: images,
+                                    files: files,
                                     model: self.selectedModel,
                                     stream: self.streamEnabled)
         }
@@ -483,7 +485,10 @@ extension MainViewController: UIImagePickerControllerDelegate, UINavigationContr
 extension MainViewController: UIDocumentPickerDelegate {
     func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
         controller.dismiss(animated: true)
-        // 파일 처리 로직 추가 가능
+        guard !urls.isEmpty else { return }
+        var current = composerView.selectedFiles.value
+        current.append(contentsOf: urls)
+        composerView.selectedFiles.accept(current)
     }
 }
 

--- a/chatGPT/Service/OpenAIEndPoint.swift
+++ b/chatGPT/Service/OpenAIEndPoint.swift
@@ -17,6 +17,13 @@ enum OpenAIEndpoint {
         stream: Bool = false,
         temperature: Double = 0.7
     )
+
+    case vision(
+        messages: [VisionMessage],
+        model: OpenAIModel,
+        stream: Bool = false,
+        temperature: Double = 0.7
+    )
     
     /// 사용가능모델
     case models
@@ -25,7 +32,9 @@ enum OpenAIEndpoint {
         switch self {
         case .chat:
             return "/chat/completions"
-            
+        case .vision:
+            return "/chat/completions"
+
         case .models:
             return "/models"
         }
@@ -33,7 +42,7 @@ enum OpenAIEndpoint {
     
     var method: HTTPMethod {
         switch self {
-        case .chat:
+        case .chat, .vision:
             return .post
         case .models:
             return .get
@@ -46,10 +55,17 @@ enum OpenAIEndpoint {
         ]
     }
     
-    var encodableBody: OpenAIChatRequest? {
+    var encodableBody: Encodable? {
         switch self {
         case .chat(let messages, let model, let stream, let temp):
             return OpenAIChatRequest(
+                model: model.id,
+                messages: messages,
+                temperature: temp,
+                stream: stream
+            )
+        case .vision(let messages, let model, let stream, let temp):
+            return OpenAIVisionChatRequest(
                 model: model.id,
                 messages: messages,
                 temperature: temp,


### PR DESCRIPTION
## Summary
- support Vision chat messages with PDF or image attachment
- add new `OpenAIVisionModels` to encode vision messages
- handle attachments in composer view and view model
- update OpenAI endpoint and repository for vision API

## Testing
- `swift test` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_6878f37c4514832b923b48cedebaf166