### PR TITLE
Fix vision request format

### DIFF
--- a/chatGPT/Domain/Entity/OpenAIVisionModels.swift
+++ b/chatGPT/Domain/Entity/OpenAIVisionModels.swift
@@ -1,9 +1,14 @@
 import Foundation
 
+struct VisionImageURL: Encodable {
+    let url: String
+    let detail: String?
+}
+
 struct VisionContent: Encodable {
     let type: String
     let text: String?
-    let imageURL: String?
+    let imageURL: VisionImageURL?
 
     enum CodingKeys: String, CodingKey {
         case type, text

--- a/chatGPT/Domain/UseCase/SendChatWithContextUseCase.swift
+++ b/chatGPT/Domain/UseCase/SendChatWithContextUseCase.swift
@@ -64,11 +64,13 @@ final class SendChatWithContextUseCase {
         var contents: [VisionContent] = [.init(type: "text", text: prompt, imageURL: nil)]
         images.forEach { data in
             let b64 = data.base64EncodedString()
-            contents.append(VisionContent(type: "image_url", text: nil, imageURL: "data:image/jpeg;base64,\(b64)"))
+            let url = VisionImageURL(url: "data:image/jpeg;base64,\(b64)", detail: nil)
+            contents.append(VisionContent(type: "image_url", text: nil, imageURL: url))
         }
         files.forEach { data in
             let b64 = data.base64EncodedString()
-            contents.append(VisionContent(type: "image_url", text: nil, imageURL: "data:application/pdf;base64,\(b64)"))
+            let url = VisionImageURL(url: "data:application/pdf;base64,\(b64)", detail: nil)
+            contents.append(VisionContent(type: "image_url", text: nil, imageURL: url))
         }
         visionMessages.append(VisionMessage(role: .user, content: contents))
 
@@ -109,11 +111,13 @@ final class SendChatWithContextUseCase {
         var contents: [VisionContent] = [.init(type: "text", text: prompt, imageURL: nil)]
         images.forEach { data in
             let b64 = data.base64EncodedString()
-            contents.append(VisionContent(type: "image_url", text: nil, imageURL: "data:image/jpeg;base64,\(b64)"))
+            let url = VisionImageURL(url: "data:image/jpeg;base64,\(b64)", detail: nil)
+            contents.append(VisionContent(type: "image_url", text: nil, imageURL: url))
         }
         files.forEach { data in
             let b64 = data.base64EncodedString()
-            contents.append(VisionContent(type: "image_url", text: nil, imageURL: "data:application/pdf;base64,\(b64)"))
+            let url = VisionImageURL(url: "data:application/pdf;base64,\(b64)", detail: nil)
+            contents.append(VisionContent(type: "image_url", text: nil, imageURL: url))
         }
         visionMessages.append(VisionMessage(role: .user, content: contents))
 


### PR DESCRIPTION
## Summary
- fix image payload for Vision API by sending nested url field
- update use case to wrap base64 image data in `VisionImageURL`

## Testing
- `swift test` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_6878f869eda4832b897d04e319780c4e