### PR TITLE
Add Storage rules docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,3 +268,6 @@ Firestore에 저장되는 `preferences`와 `conversations` 컬렉션은 인증�
 
 Firebase 콘솔의 **Firestore Database > 규칙** 탭에서 [`firebase/firestore_rules.md`](firebase/firestore_rules.md) 파일의 내용을 적용하세요.
 또한 `/models` 컬렉션에 대한 규칙도 동일하게 설정해야 합니다.
+
+Firebase 콘솔의 **Storage > 규칙** 탭에서는 [`firebase/storage_rules.md`](firebase/storage_rules.md) 파일을 적용해
+각 사용자의 `attachments/<uid>` 폴더만 접근 가능하도록 제한하세요.

--- a/firebase/storage_rules.md
+++ b/firebase/storage_rules.md
@@ -1,0 +1,14 @@
+# Firebase Storage 보안 규칙 예시
+
+Firebase 콘솔에서 **Storage** 메뉴의 **규칙** 탭에 아래 내용을 설정하세요.
+
+```javascript
+rules_version = '2';
+service firebase.storage {
+  match /b/{bucket}/o {
+    match /attachments/{userId}/{allPaths=**} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+  }
+}
+```


### PR DESCRIPTION
## Summary
- document Firebase Storage rules for `attachments/<uid>` directory
- reference storage rules in README

## Testing
- `swift test` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_687928dd2468832bb157858e662e247c