### PR TITLE
Update message images layout

### DIFF
--- a/chatGPT/Presentation/Scene/Cells/ChatMessageCell.swift
+++ b/chatGPT/Presentation/Scene/Cells/ChatMessageCell.swift
@@ -43,13 +43,19 @@ final class ChatMessageCell: UITableViewCell {
         view.alignment = .leading
         return view
     }()
-    private let userImageScrollView = UIScrollView()
-    private let userImageStackView: UIStackView = {
-        let view = UIStackView()
-        view.axis = .horizontal
-        view.spacing = 8
+    private lazy var userImageCollectionView: UICollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        layout.minimumInteritemSpacing = 8
+        layout.minimumLineSpacing = 8
+        layout.itemSize = CGSize(width: 56, height: 56)
+        let view = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        view.isScrollEnabled = false
+        view.backgroundColor = .clear
+        view.dataSource = self
+        view.register(ChatMessageImageCell.self, forCellWithReuseIdentifier: "ChatMessageImageCell")
         return view
     }()
+    private var userImageUrls: [URL] = []
     private var userImageHeightConstraint: Constraint?
     private var messageTopConstraint: Constraint?
     private var stackTopConstraint: Constraint?
@@ -71,29 +77,23 @@ final class ChatMessageCell: UITableViewCell {
 
         bubbleView.clipsToBounds = true
 
-        [userImageScrollView, bubbleView].forEach(contentView.addSubview)
-        userImageScrollView.addSubview(userImageStackView)
+        [userImageCollectionView, bubbleView].forEach(contentView.addSubview)
         [attachmentsStackView, messageView, stackView].forEach(bubbleView.addSubview)
 
         stackView.isHidden = true
         messageView.isHidden = false
 
-        userImageScrollView.showsHorizontalScrollIndicator = true
-        userImageScrollView.isHidden = true
-        userImageStackView.axis = .horizontal
-        userImageStackView.spacing = 8
+        userImageCollectionView.isHidden = true
 
-        userImageScrollView.snp.makeConstraints { make in
-            make.top.leading.trailing.equalToSuperview().inset(16)
+        userImageCollectionView.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(16)
+            make.trailing.equalToSuperview().inset(16)
+            make.leading.greaterThanOrEqualToSuperview().inset(UIScreen.main.bounds.width * 0.2)
             userImageHeightConstraint = make.height.equalTo(0).constraint
         }
 
-        userImageStackView.snp.makeConstraints { make in
-            make.edges.equalToSuperview()
-        }
-
         bubbleView.snp.makeConstraints { make in
-            make.top.equalTo(userImageScrollView.snp.bottom).offset(8).priority(999)
+            make.top.equalTo(userImageCollectionView.snp.bottom).offset(8).priority(999)
             make.bottom.equalToSuperview().inset(8).priority(999)
             make.leading.equalToSuperview().inset(16)
             make.trailing.equalToSuperview().inset(16)
@@ -223,8 +223,9 @@ final class ChatMessageCell: UITableViewCell {
         attachmentsStackView.isHidden = true
         messageTopConstraint?.update(offset: 0)
         stackTopConstraint?.update(offset: 0)
-        userImageStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
-        userImageScrollView.isHidden = true
+        userImageUrls.removeAll()
+        userImageCollectionView.reloadData()
+        userImageCollectionView.isHidden = true
         userImageHeightConstraint?.update(offset: 0)
         disposeBag = DisposeBag()
         lastHeight = 0
@@ -237,7 +238,7 @@ final class ChatMessageCell: UITableViewCell {
     func configure(with message: ChatViewModel.ChatMessage,
                    parser: ParseMarkdownUseCase) {
         attachmentsStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
-        userImageStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        userImageUrls.removeAll()
 
         let urls = message.urls.compactMap { URL(string: $0) }
         let imageExts = ["png","jpg","jpeg","gif","heic","heif","webp"]
@@ -246,19 +247,14 @@ final class ChatMessageCell: UITableViewCell {
 
         if message.type == .user {
             if imageUrls.isEmpty {
-                userImageScrollView.isHidden = true
+                userImageCollectionView.isHidden = true
                 userImageHeightConstraint?.update(offset: 0)
             } else {
-                userImageScrollView.isHidden = false
-                userImageHeightConstraint?.update(offset: 80)
-                for url in imageUrls {
-                    let view = RemoteImageView(url: url)
-                    userImageStackView.addArrangedSubview(view)
-                    view.snp.makeConstraints { make in
-                        make.width.equalTo(80)
-                        make.height.equalToSuperview()
-                    }
-                }
+                userImageUrls = imageUrls
+                userImageCollectionView.reloadData()
+                userImageCollectionView.layoutIfNeeded()
+                userImageCollectionView.isHidden = false
+                userImageHeightConstraint?.update(offset: userImageCollectionView.collectionViewLayout.collectionViewContentSize.height)
             }
 
             if fileUrls.isEmpty {
@@ -281,7 +277,7 @@ final class ChatMessageCell: UITableViewCell {
                 }
             }
         } else {
-            userImageScrollView.isHidden = true
+            userImageCollectionView.isHidden = true
             userImageHeightConstraint?.update(offset: 0)
             if urls.isEmpty {
                 attachmentsStackView.isHidden = true
@@ -336,7 +332,7 @@ final class ChatMessageCell: UITableViewCell {
                 make.edges.equalToSuperview().inset(12).priority(999)
             }
             bubbleView.snp.remakeConstraints { make in
-                make.top.equalTo(userImageScrollView.snp.bottom).offset(8).priority(999)
+                make.top.equalTo(userImageCollectionView.snp.bottom).offset(8).priority(999)
                 make.bottom.equalToSuperview().inset(8).priority(999)
                 make.trailing.equalToSuperview().inset(16)
                 make.leading.greaterThanOrEqualToSuperview().inset(UIScreen.main.bounds.width * 0.2)
@@ -351,7 +347,7 @@ final class ChatMessageCell: UITableViewCell {
                 make.edges.equalToSuperview().priority(999)
             }
             bubbleView.snp.remakeConstraints { make in
-                make.top.equalTo(userImageScrollView.snp.bottom).offset(8).priority(999)
+                make.top.equalTo(userImageCollectionView.snp.bottom).offset(8).priority(999)
                 make.bottom.equalToSuperview().inset(8).priority(999)
                 make.leading.trailing.equalToSuperview().inset(16)
             }
@@ -365,7 +361,7 @@ final class ChatMessageCell: UITableViewCell {
                 make.edges.equalToSuperview().inset(12).priority(999)
             }
             bubbleView.snp.remakeConstraints { make in
-                make.top.equalTo(userImageScrollView.snp.bottom).offset(8).priority(999)
+                make.top.equalTo(userImageCollectionView.snp.bottom).offset(8).priority(999)
                 make.bottom.equalToSuperview().inset(8).priority(999)
                 make.leading.equalToSuperview().inset(16)
                 make.trailing.lessThanOrEqualToSuperview().inset(UIScreen.main.bounds.width * 0.2)
@@ -374,7 +370,7 @@ final class ChatMessageCell: UITableViewCell {
 
         layoutIfNeeded()
         let attachmentHeight = attachmentsStackView.isHidden ? 0 : attachmentsStackView.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).height + 8
-        let imageHeight = userImageScrollView.isHidden ? 0 : (userImageHeightConstraint?.layoutConstraints.first?.constant ?? 80) + 8
+        let imageHeight = userImageCollectionView.isHidden ? 0 : (userImageHeightConstraint?.layoutConstraints.first?.constant ?? 56) + 8
         if stackView.isHidden {
             messageView.addAttachmentViews()
             lastHeight = messageView.contentSize.height + attachmentHeight + imageHeight
@@ -391,7 +387,7 @@ final class ChatMessageCell: UITableViewCell {
             layoutIfNeeded()
             messageView.addAttachmentViews()
             let attach = attachmentsStackView.isHidden ? 0 : attachmentsStackView.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).height + 8
-            let images = userImageScrollView.isHidden ? 0 : (userImageHeightConstraint?.layoutConstraints.first?.constant ?? 80) + 8
+            let images = userImageCollectionView.isHidden ? 0 : (userImageHeightConstraint?.layoutConstraints.first?.constant ?? 56) + 8
             let newHeight = messageView.contentSize.height + attach + images
             defer { lastHeight = newHeight }
             return newHeight != lastHeight
@@ -400,11 +396,22 @@ final class ChatMessageCell: UITableViewCell {
             buildStack(from: attributed)
             layoutIfNeeded()
             let attach = attachmentsStackView.isHidden ? 0 : attachmentsStackView.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).height + 8
-            let images = userImageScrollView.isHidden ? 0 : (userImageHeightConstraint?.layoutConstraints.first?.constant ?? 80) + 8
+            let images = userImageCollectionView.isHidden ? 0 : (userImageHeightConstraint?.layoutConstraints.first?.constant ?? 56) + 8
             let newHeight = stackView.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).height + attach + images
             defer { lastHeight = newHeight }
             return newHeight != lastHeight
         }
     }
+}
 
+extension ChatMessageCell: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        userImageUrls.count
+    }
+
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "ChatMessageImageCell", for: indexPath) as! ChatMessageImageCell
+        cell.configure(url: userImageUrls[indexPath.item])
+        return cell
+    }
 }

--- a/chatGPT/Presentation/Scene/Cells/ChatMessageImageCell.swift
+++ b/chatGPT/Presentation/Scene/Cells/ChatMessageImageCell.swift
@@ -1,0 +1,24 @@
+import UIKit
+import SnapKit
+
+final class ChatMessageImageCell: UICollectionViewCell {
+    private var imageView: RemoteImageView?
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+
+    func configure(url: URL) {
+        imageView?.removeFromSuperview()
+        let view = RemoteImageView(url: url)
+        contentView.addSubview(view)
+        view.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+        imageView = view
+    }
+}


### PR DESCRIPTION
## Summary
- show user images in a grid
- align image group with the bubble
- add collection view cell for message images

## Testing
- `swift build` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_687a6197d288832bb69730bbe9f1796e