### PR TITLE
Update layout for user images

### DIFF
--- a/chatGPT/Presentation/Scene/Cells/ChatMessageCell.swift
+++ b/chatGPT/Presentation/Scene/Cells/ChatMessageCell.swift
@@ -89,7 +89,8 @@ final class ChatMessageCell: UITableViewCell {
         }
 
         userImageStackView.snp.makeConstraints { make in
-            make.edges.equalToSuperview()
+            make.top.bottom.trailing.equalToSuperview()
+            make.leading.greaterThanOrEqualToSuperview()
         }
 
         bubbleView.snp.makeConstraints { make in
@@ -257,6 +258,11 @@ final class ChatMessageCell: UITableViewCell {
                     view.snp.makeConstraints { make in
                         make.width.equalTo(80)
                     }
+                }
+                DispatchQueue.main.async { [weak self] in
+                    guard let self else { return }
+                    let offset = max(0, self.userImageScrollView.contentSize.width - self.userImageScrollView.bounds.width)
+                    self.userImageScrollView.contentOffset.x = offset
                 }
             }
 


### PR DESCRIPTION
## Summary
- pin `userImageStackView` to the trailing edge so user images align right
- scroll user image list to trailing when images are added

## Testing
- `swift test -c debug` *(fails: no UIKit module)*

------
https://chatgpt.com/codex/tasks/task_e_687d13e725e8832b92b962bc42711f8c