### PR TITLE
Add rtl layout for user images

### DIFF
--- a/chatGPT/Presentation/Scene/Cells/ChatMessageCell.swift
+++ b/chatGPT/Presentation/Scene/Cells/ChatMessageCell.swift
@@ -82,6 +82,8 @@ final class ChatMessageCell: UITableViewCell {
         userImageScrollView.isHidden = true
         userImageStackView.axis = .horizontal
         userImageStackView.spacing = 8
+        userImageStackView.semanticContentAttribute = .forceRightToLeft
+        userImageScrollView.semanticContentAttribute = .forceRightToLeft
 
         userImageScrollView.snp.makeConstraints { make in
             make.top.leading.trailing.equalToSuperview().inset(16)
@@ -258,11 +260,6 @@ final class ChatMessageCell: UITableViewCell {
                     view.snp.makeConstraints { make in
                         make.width.equalTo(80)
                     }
-                }
-                DispatchQueue.main.async { [weak self] in
-                    guard let self else { return }
-                    let offset = max(0, self.userImageScrollView.contentSize.width - self.userImageScrollView.bounds.width)
-                    self.userImageScrollView.contentOffset.x = offset
                 }
             }
 


### PR DESCRIPTION
## Summary
- update chat message cell layout for right-to-left images
- clean up manual offset logic

## Testing
- `swift test -l` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_687df5b55b78832baf9ee4e548866e9e