### PR TITLE
Update layout style options

### DIFF
--- a/chatGPT/Components/RemoteImageGroupAttachment.swift
+++ b/chatGPT/Components/RemoteImageGroupAttachment.swift
@@ -4,9 +4,9 @@ final class RemoteImageGroupAttachment: NSTextAttachment {
     let urls: [URL]
     let view: RemoteImageGroupView
 
-    init(urls: [URL]) {
+    init(urls: [URL], style: RemoteImageGroupView.Style = .horizontal) {
         self.urls = urls
-        self.view = RemoteImageGroupView(urls: urls)
+        self.view = RemoteImageGroupView(urls: urls, style: style)
         super.init(data: nil, ofType: nil)
     }
 

--- a/chatGPT/Components/RemoteImageGroupView.swift
+++ b/chatGPT/Components/RemoteImageGroupView.swift
@@ -4,14 +4,28 @@ import RxSwift
 import RxCocoa
 
 final class RemoteImageGroupView: UIView {
+    enum Style {
+        case horizontal
+        case grid
+    }
+
     private let collectionView: UICollectionView
     private let urls: [URL]
+    private let style: Style
     private let disposeBag = DisposeBag()
 
-    init(urls: [URL]) {
+    init(urls: [URL], style: Style = .horizontal) {
         self.urls = urls
-        let layout = UICollectionViewFlowLayout()
-        layout.scrollDirection = .horizontal
+        self.style = style
+        let layout: UICollectionViewFlowLayout
+        switch style {
+        case .horizontal:
+            layout = UICollectionViewFlowLayout()
+            layout.scrollDirection = .horizontal
+        case .grid:
+            layout = TrailingFlowLayout()
+            layout.scrollDirection = .vertical
+        }
         layout.minimumLineSpacing = 8
         layout.minimumInteritemSpacing = 8
         self.collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
@@ -28,7 +42,8 @@ final class RemoteImageGroupView: UIView {
         backgroundColor = ThemeColor.background1
         addSubview(collectionView)
         collectionView.backgroundColor = .clear
-        collectionView.showsHorizontalScrollIndicator = true
+        collectionView.showsHorizontalScrollIndicator = style == .horizontal
+        collectionView.isScrollEnabled = style == .horizontal
         collectionView.register(RemoteImageCollectionCell.self, forCellWithReuseIdentifier: "RemoteImageCollectionCell")
         collectionView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
@@ -52,7 +67,15 @@ final class RemoteImageGroupView: UIView {
 
 extension RemoteImageGroupView: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        let width = collectionView.bounds.width * 0.65
-        return CGSize(width: width, height: width)
+        switch style {
+        case .horizontal:
+            let width = collectionView.bounds.width * 0.65
+            return CGSize(width: width, height: width)
+        case .grid:
+            let layout = collectionViewLayout as? UICollectionViewFlowLayout
+            let spacing = layout?.minimumInteritemSpacing ?? 8
+            let width = (collectionView.bounds.width - spacing * 2) / 3
+            return CGSize(width: width, height: width)
+        }
     }
 }

--- a/chatGPT/Data/SwiftMarkdownRepository.swift
+++ b/chatGPT/Data/SwiftMarkdownRepository.swift
@@ -171,7 +171,7 @@ final class SwiftMarkdownRepository: MarkdownRepository {
                 guard let url = URL(string: urlString) else { return parseInline(text) }
                 urls.append(url)
             }
-            let attachment = RemoteImageGroupAttachment(urls: urls)
+            let attachment = RemoteImageGroupAttachment(urls: urls, style: .grid)
             return NSAttributedString(attachment: attachment)
         }
 
@@ -242,7 +242,7 @@ final class SwiftMarkdownRepository: MarkdownRepository {
                     j += 1
                 }
                 if urls.count > 1 {
-                    let attachment = RemoteImageGroupAttachment(urls: urls)
+                    let attachment = RemoteImageGroupAttachment(urls: urls, style: .grid)
                     result.append(NSAttributedString(attachment: attachment))
                 } else if let url = urls.first {
                     let attachment = RemoteImageAttachment(url: url, altText: parts.first?.1 ?? "")


### PR DESCRIPTION
## Summary
- allow `RemoteImageGroupView` to use horizontal or grid layout
- use the same trailing grid layout for markdown image groups
- support style in `RemoteImageGroupAttachment`

## Testing
- `swift test` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_687e50f2c598832bbe9d8e0e46bdab6f