### PR TITLE
Fix user image grid alignment

### DIFF
--- a/chatGPT/Presentation/Scene/Cells/ChatMessageCell.swift
+++ b/chatGPT/Presentation/Scene/Cells/ChatMessageCell.swift
@@ -88,8 +88,9 @@ final class ChatMessageCell: UITableViewCell {
     // 유저 이미지 행 수 기반 높이 계산
     private func expectedUserImageHeight(for count: Int) -> CGFloat {
         guard count > 0 else { return 0 }
-        let item = UIScreen.main.bounds.width * 0.15
+        let width = UIScreen.main.bounds.width - 32
         let spacing: CGFloat = 8
+        let item = (width - spacing * 3) / 4
         let rows = Int(ceil(Double(count) / 4.0))
         return CGFloat(rows) * item + CGFloat(max(rows - 1, 0)) * spacing
     }
@@ -298,6 +299,7 @@ final class ChatMessageCell: UITableViewCell {
     // 서브뷰 레이아웃 후 추가 처리 필요 시 사용
     override func layoutSubviews() {
         super.layoutSubviews()
+        userImageCollectionView.collectionViewLayout.invalidateLayout()
     }
 
     // 셀 내용을 주어진 메시지로 구성
@@ -492,8 +494,10 @@ final class ChatMessageCell: UITableViewCell {
 extension ChatMessageCell: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         if collectionView == userImageCollectionView {
-            let size = UIScreen.main.bounds.width * 0.15
-            return CGSize(width: size, height: size)
+            let layout = collectionViewLayout as? UICollectionViewFlowLayout
+            let spacing = layout?.minimumInteritemSpacing ?? 8
+            let width = (collectionView.bounds.width - spacing * 3) / 4
+            return CGSize(width: width, height: width)
         }
         let width = collectionView.bounds.width * 0.65
         return CGSize(width: width, height: width)
@@ -503,8 +507,10 @@ extension ChatMessageCell: UICollectionViewDelegateFlowLayout {
         guard collectionView == userImageCollectionView else { return .zero }
         let layout = collectionViewLayout as? UICollectionViewFlowLayout
         let spacing = layout?.minimumInteritemSpacing ?? 8
-        let item = UIScreen.main.bounds.width * 0.15
-        let rowWidth = item * 4 + spacing * 3
+        let itemCount = collectionView.numberOfItems(inSection: section)
+        let width = (collectionView.bounds.width - spacing * 3) / 4
+        let rowCount = min(itemCount, 4)
+        let rowWidth = CGFloat(rowCount) * width + CGFloat(max(rowCount - 1, 0)) * spacing
         let inset = max((collectionView.bounds.width - rowWidth) / 2, 0)
         return UIEdgeInsets(top: 0, left: inset, bottom: 0, right: inset)
     }


### PR DESCRIPTION
## Summary
- fix item size calculation and inset for user image grid
- invalidate collection layout on layout pass

## Testing
- `swift test -l` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_687f7a36a324832bb79d5de238275c44