### PR TITLE
update tests for image intent usecase

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,11 +3,19 @@
 
 import PackageDescription
 
+let packageDependencies: [Package.Dependency] = [
+    .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "6.9.0")
+]
+
 var targets: [Target] = []
 #if os(iOS)
 targets.append(
     .executableTarget(
         name: "chatGPT",
+        dependencies: [
+            .product(name: "RxSwift", package: "RxSwift"),
+            .product(name: "RxCocoa", package: "RxSwift")
+        ],
         path: "chatGPT"
     )
 )
@@ -15,7 +23,10 @@ targets.append(
 targets.append(
     .testTarget(
         name: "chatGPTTests",
-        dependencies: [],
+        dependencies: [
+            "chatGPT",
+            .product(name: "RxSwift", package: "RxSwift")
+        ],
         path: "chatGPTTests"
     )
 )
@@ -24,5 +35,6 @@ let package = Package(
     name: "chatGPT",
     defaultLocalization: "ko",
     platforms: [.iOS(.v18)],
+    dependencies: packageDependencies,
     targets: targets
 )

--- a/chatGPTTests/DetectImageRequestUseCaseTests.swift
+++ b/chatGPTTests/DetectImageRequestUseCaseTests.swift
@@ -1,48 +1,112 @@
 import XCTest
+import RxSwift
+@testable import chatGPT
 
-final class DetectImageRequestUseCase {
-    private let keywords: [String]
-    private let negativeIndicators: [String]
+final class StubOpenAIRepository: OpenAIRepository {
+    var result: Single<Bool> = .just(false)
+    private(set) var receivedPrompt: String?
 
-    init(keywords: [String] = ["이미지", "그림", "사진", "image", "picture"], negativeIndicators: [String] = ["하지마", "하지 마", "만들지마", "만들지 마", "그리지마", "그리지 마", "no", "don't", "dont", "not"]) {
-        self.keywords = keywords
-        self.negativeIndicators = negativeIndicators
+    func detectImageIntent(prompt: String) -> Single<Bool> {
+        receivedPrompt = prompt
+        return result
     }
 
-    func execute(prompt: String) -> Bool {
-        let lowerPrompt = prompt.lowercased()
-        if negativeIndicators.contains(where: { lowerPrompt.contains($0.lowercased()) }) {
-            return false
-        }
-        return keywords.contains { lowerPrompt.contains($0.lowercased()) }
-    }
+    func fetchAvailableModels(completion: @escaping (Result<[OpenAIModel], Error>) -> Void) {}
+    func sendChat(messages: [Message], model: OpenAIModel, stream: Bool, completion: @escaping (Result<String, Error>) -> Void) {}
+    func sendChatStream(messages: [Message], model: OpenAIModel) -> Observable<String> { .empty() }
+    func sendVision(messages: [VisionMessage], model: OpenAIModel, stream: Bool, completion: @escaping (Result<String, Error>) -> Void) {}
+    func sendVisionStream(messages: [VisionMessage], model: OpenAIModel) -> Observable<String> { .empty() }
+    func generateImage(prompt: String, size: String, completion: @escaping (Result<[String], Error>) -> Void) {}
 }
 
 final class DetectImageRequestUseCaseTests: XCTestCase {
     private var useCase: DetectImageRequestUseCase!
+    private var repository: StubOpenAIRepository!
+    private var disposeBag: DisposeBag!
 
     override func setUp() {
         super.setUp()
-        useCase = DetectImageRequestUseCase()
+        repository = StubOpenAIRepository()
+        useCase = DetectImageRequestUseCase(repository: repository)
+        disposeBag = DisposeBag()
     }
 
     func test_positive_detection() {
         let prompt = "이미지 만들어줘"
-        XCTAssertTrue(useCase.execute(prompt: prompt))
+        repository.result = .just(true)
+        let exp = expectation(description: "positive")
+        var output = false
+        useCase.execute(prompt: prompt)
+            .subscribe(onSuccess: { value in
+                output = value
+                exp.fulfill()
+            })
+            .disposed(by: disposeBag)
+        waitForExpectations(timeout: 1)
+        XCTAssertTrue(output)
+        XCTAssertEqual(repository.receivedPrompt, prompt)
     }
 
     func test_negative_sentence() {
         let prompt = "이미지는 만들지마"
-        XCTAssertFalse(useCase.execute(prompt: prompt))
+        repository.result = .just(false)
+        let exp = expectation(description: "negative")
+        var output = true
+        useCase.execute(prompt: prompt)
+            .subscribe(onSuccess: { value in
+                output = value
+                exp.fulfill()
+            })
+            .disposed(by: disposeBag)
+        waitForExpectations(timeout: 1)
+        XCTAssertFalse(output)
+        XCTAssertEqual(repository.receivedPrompt, prompt)
     }
 
     func test_detection_in_english() {
         let prompt = "please generate an image"
-        XCTAssertTrue(useCase.execute(prompt: prompt))
+        repository.result = .just(true)
+        let exp = expectation(description: "english")
+        var output = false
+        useCase.execute(prompt: prompt)
+            .subscribe(onSuccess: { value in
+                output = value
+                exp.fulfill()
+            })
+            .disposed(by: disposeBag)
+        waitForExpectations(timeout: 1)
+        XCTAssertTrue(output)
+        XCTAssertEqual(repository.receivedPrompt, prompt)
     }
 
     func test_detection_in_other_language() {
         let prompt = "por favor no hagas una imagen"
-        XCTAssertFalse(useCase.execute(prompt: prompt))
+        repository.result = .just(false)
+        let exp = expectation(description: "spanish")
+        var output = true
+        useCase.execute(prompt: prompt)
+            .subscribe(onSuccess: { value in
+                output = value
+                exp.fulfill()
+            })
+            .disposed(by: disposeBag)
+        waitForExpectations(timeout: 1)
+        XCTAssertFalse(output)
+        XCTAssertEqual(repository.receivedPrompt, prompt)
+    }
+
+    func test_detection_returnsFalse_onError() {
+        enum TestError: Error { case sample }
+        repository.result = .error(TestError.sample)
+        let exp = expectation(description: "error")
+        var output = true
+        useCase.execute(prompt: "error")
+            .subscribe(onSuccess: { value in
+                output = value
+                exp.fulfill()
+            })
+            .disposed(by: disposeBag)
+        waitForExpectations(timeout: 1)
+        XCTAssertFalse(output)
     }
 }


### PR DESCRIPTION
## Summary
- replace the temporary DetectImageRequestUseCase in tests with the real one
- add stub repository and async expectations using RxSwift Single
- include new RxSwift dependencies in `Package.swift`
- add test for error handling

## Testing
- `swift test -c release` *(fails: Could not fetch RxSwift package)*

------
https://chatgpt.com/codex/tasks/task_e_6880fca688e8832b8588bd86ac333f30