### PR TITLE
feature/save-image-url

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,10 +263,10 @@ UIKit 기반 구성 요소 및 커스텀 UI 모두 traitCollection에 따라 적
 
 ## 🖼️ 이미지 생성 기능
 
-OpenAI의 DALL·E API를 이용해 원하는 이미지를 만들 수 있습니다. `ChatViewModel`의 `generateImage(prompt:size:)` 메서드를 호출하면 이미지 URL 목록을 반환하며, 앱에서는 해당 URL을 불러와 바로 표시합니다.
+OpenAI의 DALL·E API를 이용해 원하는 이미지를 만들 수 있습니다. `ChatViewModel`의 `generateImage(prompt:size:model:)` 메서드를 호출하면 이미지 URL 목록을 반환하며, 앱에서는 해당 URL을 불러와 바로 표시합니다.
 
 ```
-viewModel.generateImage(prompt: "A cute cat", size: "512x512")
+viewModel.generateImage(prompt: "A cute cat", size: "512x512", model: .gpt3_5Turbo)
 ```
 
 실행 결과 이미지는 메시지와 동일한 형태로 채팅 화면에 표시됩니다.


### PR DESCRIPTION
## Summary
- store generated image URLs in Firestore
- update image generation API usage

## Testing
- `swift test` *(fails: unable to access github.com)*

------
https://chatgpt.com/codex/tasks/task_e_6881e931a720832b9ab883fe367f47d1