### PR TITLE
Support image edit requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,11 +263,13 @@ UIKit 기반 구성 요소 및 커스텀 UI 모두 traitCollection에 따라 적
 
 ## 🖼️ 이미지 생성 기능
 
-OpenAI의 DALL·E API를 이용해 원하는 이미지를 만들 수 있습니다. `ChatViewModel`의 `generateImage(prompt:size:model:)` 메서드에 생성 모델 문자열을 전달해 원하는 버전을 지정할 수 있습니다.
+OpenAI의 DALL·E API를 이용해 원하는 이미지를 만들 수 있습니다. `ChatViewModel`의 `generateImage(prompt:size:model:attachments:)` 메서드에 생성 모델 문자열을 전달해 원하는 버전을 지정할 수 있습니다.
 
 ```
 viewModel.generateImage(prompt: "A cute cat", size: "512x512", model: "dall-e-3")
 ```
+
+이미지 파일을 `attachments` 파라미터로 전달하면 기존 이미지를 원하는 형태로 수정할 수도 있습니다.
 
 `model` 파라미터에 "dall-e-3" 또는 "dall-e-2" 등을 지정하여 원하는 이미지 생성 모델을 선택할 수 있습니다.
 

--- a/chatGPT/Data/OpenAIRepository.swift
+++ b/chatGPT/Data/OpenAIRepository.swift
@@ -16,6 +16,8 @@ protocol OpenAIRepository {
     func sendVisionStream(messages: [VisionMessage], model: OpenAIModel) -> Observable<String>
 
     func generateImage(prompt: String, size: String, model: String, completion: @escaping (Result<[String], Error>) -> Void)
+    func generateImageVariation(image: Data, size: String, model: String, completion: @escaping (Result<[String], Error>) -> Void)
+    func generateImageEdit(image: Data, prompt: String, size: String, model: String, completion: @escaping (Result<[String], Error>) -> Void)
 
     func detectImageIntent(prompt: String) -> Single<Bool>
 }

--- a/chatGPT/Data/OpenAIRepositoryImpl.swift
+++ b/chatGPT/Data/OpenAIRepositoryImpl.swift
@@ -60,6 +60,30 @@ final class OpenAIRepositoryImpl: OpenAIRepository {
         }
     }
 
+    func generateImageVariation(image: Data, size: String, model: String, completion: @escaping (Result<[String], Error>) -> Void) {
+        service.upload(.imageVariation(image: image, size: size, model: model)) { (result: Result<OpenAIImageResponse, Error>) in
+            switch result {
+            case .success(let response):
+                let urls = response.data.map { $0.url }
+                completion(.success(urls))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+
+    func generateImageEdit(image: Data, prompt: String, size: String, model: String, completion: @escaping (Result<[String], Error>) -> Void) {
+        service.upload(.imageEdit(image: image, prompt: prompt, size: size, model: model)) { (result: Result<OpenAIImageResponse, Error>) in
+            switch result {
+            case .success(let response):
+                let urls = response.data.map { $0.url }
+                completion(.success(urls))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+
     func detectImageIntent(prompt: String) -> Single<Bool> {
         Single.create { single in
             let system = Message(role: .system,

--- a/chatGPT/Domain/UseCase/GenerateImageUseCase.swift
+++ b/chatGPT/Domain/UseCase/GenerateImageUseCase.swift
@@ -7,7 +7,11 @@ final class GenerateImageUseCase {
         self.repository = repository
     }
 
-    func execute(prompt: String, size: String, model: String, completion: @escaping (Result<[String], Error>) -> Void) {
-        repository.generateImage(prompt: prompt, size: size, model: model, completion: completion)
+    func execute(prompt: String, size: String, model: String, imageData: Data? = nil, completion: @escaping (Result<[String], Error>) -> Void) {
+        if let data = imageData {
+            repository.generateImageEdit(image: data, prompt: prompt, size: size, model: model, completion: completion)
+        } else {
+            repository.generateImage(prompt: prompt, size: size, model: model, completion: completion)
+        }
     }
 }

--- a/chatGPT/Service/OpenAIServiceProtocol.swift
+++ b/chatGPT/Service/OpenAIServiceProtocol.swift
@@ -4,4 +4,5 @@ import RxSwift
 protocol OpenAIServiceProtocol {
     func request<T: Decodable>(_ endpoint: OpenAIEndpoint, completion: @escaping (Result<T, Error>) -> Void)
     func requestStream(_ endpoint: OpenAIEndpoint) -> Observable<String>
+    func upload<T: Decodable>(_ endpoint: OpenAIEndpoint, completion: @escaping (Result<T, Error>) -> Void)
 }

--- a/chatGPTTests/DetectImageRequestUseCaseTests.swift
+++ b/chatGPTTests/DetectImageRequestUseCaseTests.swift
@@ -17,6 +17,8 @@ final class StubOpenAIRepository: OpenAIRepository {
     func sendVision(messages: [VisionMessage], model: OpenAIModel, stream: Bool, completion: @escaping (Result<String, Error>) -> Void) {}
     func sendVisionStream(messages: [VisionMessage], model: OpenAIModel) -> Observable<String> { .empty() }
     func generateImage(prompt: String, size: String, model: String, completion: @escaping (Result<[String], Error>) -> Void) {}
+    func generateImageVariation(image: Data, size: String, model: String, completion: @escaping (Result<[String], Error>) -> Void) {}
+    func generateImageEdit(image: Data, prompt: String, size: String, model: String, completion: @escaping (Result<[String], Error>) -> Void) {}
 }
 
 final class DetectImageRequestUseCaseTests: XCTestCase {


### PR DESCRIPTION
## Summary
- enable editing an uploaded image with a prompt
- add `imageEdit` endpoint and repository method
- use new endpoint in image generation use case
- document editing via attachments in README

## Testing
- `swift test -c debug` *(fails: unable to access github.com)*

------
https://chatgpt.com/codex/tasks/task_e_68820655ce2c832bb9e95506ba94ccd9