### PR TITLE
codex/full-mask-support

### DIFF
--- a/chatGPT/Data/OpenAIRepository.swift
+++ b/chatGPT/Data/OpenAIRepository.swift
@@ -17,7 +17,7 @@ protocol OpenAIRepository {
 
     func generateImage(prompt: String, size: String, model: String, completion: @escaping (Result<[String], Error>) -> Void)
     func generateImageVariation(image: Data, size: String, model: String, completion: @escaping (Result<[String], Error>) -> Void)
-    func generateImageEdit(image: Data, prompt: String, size: String, model: String, completion: @escaping (Result<[String], Error>) -> Void)
+    func generateImageEdit(image: Data, mask: Data?, prompt: String, size: String, model: String, completion: @escaping (Result<[String], Error>) -> Void)
 
     func detectImageIntent(prompt: String) -> Single<Bool>
 }

--- a/chatGPT/Data/OpenAIRepositoryImpl.swift
+++ b/chatGPT/Data/OpenAIRepositoryImpl.swift
@@ -72,8 +72,8 @@ final class OpenAIRepositoryImpl: OpenAIRepository {
         }
     }
 
-    func generateImageEdit(image: Data, prompt: String, size: String, model: String, completion: @escaping (Result<[String], Error>) -> Void) {
-        service.upload(.imageEdit(image: image, prompt: prompt, size: size, model: model)) { (result: Result<OpenAIImageResponse, Error>) in
+    func generateImageEdit(image: Data, mask: Data?, prompt: String, size: String, model: String, completion: @escaping (Result<[String], Error>) -> Void) {
+        service.upload(.imageEdit(image: image, mask: mask, prompt: prompt, size: size, model: model)) { (result: Result<OpenAIImageResponse, Error>) in
             switch result {
             case .success(let response):
                 let urls = response.data.map { $0.url }

--- a/chatGPT/Domain/UseCase/GenerateImageUseCase.swift
+++ b/chatGPT/Domain/UseCase/GenerateImageUseCase.swift
@@ -7,9 +7,9 @@ final class GenerateImageUseCase {
         self.repository = repository
     }
 
-    func execute(prompt: String, size: String, model: String, imageData: Data? = nil, completion: @escaping (Result<[String], Error>) -> Void) {
+    func execute(prompt: String, size: String, model: String, imageData: Data? = nil, maskData: Data? = nil, completion: @escaping (Result<[String], Error>) -> Void) {
         if let data = imageData {
-            repository.generateImageEdit(image: data, prompt: prompt, size: size, model: model, completion: completion)
+            repository.generateImageEdit(image: data, mask: maskData, prompt: prompt, size: size, model: model, completion: completion)
         } else {
             repository.generateImage(prompt: prompt, size: size, model: model, completion: completion)
         }

--- a/chatGPT/Presentation/Helpers/UIImage.swift
+++ b/chatGPT/Presentation/Helpers/UIImage.swift
@@ -48,4 +48,14 @@ extension UIImage {
         UIGraphicsEndImageContext()
         return img?.pngData()
     }
+
+    /// 전체 영역 편집을 위한 투명 마스크 PNG 데이터 반환
+    static func fullEditMask(size: CGSize) -> Data? {
+        UIGraphicsBeginImageContextWithOptions(size, false, 1)
+        UIColor.clear.setFill()
+        UIRectFill(CGRect(origin: .zero, size: size))
+        let img = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return img?.pngData()
+    }
 }

--- a/chatGPT/Presentation/Scene/ChatViewModel.swift
+++ b/chatGPT/Presentation/Scene/ChatViewModel.swift
@@ -392,10 +392,11 @@ final class ChatViewModel {
             }
             return nil
         }.first
+        let maskData = imageData == nil ? nil : UIImage.fullEditMask(size: CGSize(width: dimension, height: dimension))
 
         let usedModel = imageData == nil ? imageModel : "dall-e-2"
 
-        generateImageUseCase.execute(prompt: prompt, size: size, model: usedModel, imageData: imageData) { [weak self] result in
+        generateImageUseCase.execute(prompt: prompt, size: size, model: usedModel, imageData: imageData, maskData: maskData) { [weak self] result in
             guard let self else { return }
             switch result {
             case .success(let urls):

--- a/chatGPT/Service/OpenAIEndPoint.swift
+++ b/chatGPT/Service/OpenAIEndPoint.swift
@@ -27,7 +27,7 @@ enum OpenAIEndpoint {
 
     case image(prompt: String, size: String, model: String)
     case imageVariation(image: Data, size: String, model: String)
-    case imageEdit(image: Data, prompt: String, size: String, model: String)
+    case imageEdit(image: Data, mask: Data?, prompt: String, size: String, model: String)
     
     /// 사용가능모델
     case models
@@ -102,9 +102,12 @@ enum OpenAIEndpoint {
                 form.append(Data(size.utf8), withName: "size")
                 form.append(Data(model.utf8), withName: "model")
             }
-        case .imageEdit(let image, let prompt, let size, let model):
+        case .imageEdit(let image, let mask, let prompt, let size, let model):
             return { form in
                 form.append(image, withName: "image", fileName: "image.png", mimeType: "image/png")
+                if let mask {
+                    form.append(mask, withName: "mask", fileName: "mask.png", mimeType: "image/png")
+                }
                 form.append(Data(prompt.utf8), withName: "prompt")
                 form.append(Data("1".utf8), withName: "n")
                 form.append(Data(size.utf8), withName: "size")

--- a/chatGPTTests/DetectImageRequestUseCaseTests.swift
+++ b/chatGPTTests/DetectImageRequestUseCaseTests.swift
@@ -18,7 +18,7 @@ final class StubOpenAIRepository: OpenAIRepository {
     func sendVisionStream(messages: [VisionMessage], model: OpenAIModel) -> Observable<String> { .empty() }
     func generateImage(prompt: String, size: String, model: String, completion: @escaping (Result<[String], Error>) -> Void) {}
     func generateImageVariation(image: Data, size: String, model: String, completion: @escaping (Result<[String], Error>) -> Void) {}
-    func generateImageEdit(image: Data, prompt: String, size: String, model: String, completion: @escaping (Result<[String], Error>) -> Void) {}
+    func generateImageEdit(image: Data, mask: Data?, prompt: String, size: String, model: String, completion: @escaping (Result<[String], Error>) -> Void) {}
 }
 
 final class DetectImageRequestUseCaseTests: XCTestCase {


### PR DESCRIPTION
## Summary
- update DALL·E edit API parameters to handle optional mask
- create helper to generate transparent mask
- pass mask for full-image edits in ChatViewModel

## Testing
- `swift test` *(fails: unable to access https://github.com/ReactiveX/RxSwift.git)*

------
https://chatgpt.com/codex/tasks/task_e_68821b74cd40832bbf08b968817f0251