### PR TITLE
Add detail viewer overlays

### DIFF
--- a/chatGPT/Presentation/Scene/Cells/ChatMessageCell.swift
+++ b/chatGPT/Presentation/Scene/Cells/ChatMessageCell.swift
@@ -344,7 +344,12 @@ final class ChatMessageCell: UITableViewCell {
                     button.setImage(image, for: .normal)
                     button.setTitle(" " + url.lastPathComponent, for: .normal)
                     button.contentHorizontalAlignment = .left
-                    button.rx.tap.bind { UIApplication.shared.open(url) }.disposed(by: disposeBag)
+                    button.rx.tap.bind {
+                        let viewer = DocumentViewerViewController(url: url)
+                        viewer.modalPresentationStyle = .overFullScreen
+                        viewer.modalTransitionStyle = .crossDissolve
+                        UIApplication.topViewController?.present(viewer, animated: true)
+                    }.disposed(by: disposeBag)
                     attachmentsStackView.addArrangedSubview(button)
                     button.snp.makeConstraints { $0.width.equalToSuperview() }
                 }
@@ -382,7 +387,12 @@ final class ChatMessageCell: UITableViewCell {
                     button.setImage(image, for: .normal)
                     button.setTitle(" " + url.lastPathComponent, for: .normal)
                     button.contentHorizontalAlignment = .left
-                    button.rx.tap.bind { UIApplication.shared.open(url) }.disposed(by: disposeBag)
+                    button.rx.tap.bind {
+                        let viewer = DocumentViewerViewController(url: url)
+                        viewer.modalPresentationStyle = .overFullScreen
+                        viewer.modalTransitionStyle = .crossDissolve
+                        UIApplication.topViewController?.present(viewer, animated: true)
+                    }.disposed(by: disposeBag)
                     attachmentsStackView.addArrangedSubview(button)
                     button.snp.makeConstraints { $0.width.equalToSuperview() }
                 }

--- a/chatGPT/Presentation/Scene/DocumentViewerViewController.swift
+++ b/chatGPT/Presentation/Scene/DocumentViewerViewController.swift
@@ -1,0 +1,114 @@
+import UIKit
+import SnapKit
+import RxSwift
+import RxCocoa
+import QuickLook
+
+final class DocumentViewerViewController: UIViewController {
+    private let url: URL
+    private let previewController = QLPreviewController()
+    private let disposeBag = DisposeBag()
+    private let bottomView = UIView()
+    private let saveButton = UIButton(type: .system)
+    private let shareButton = UIButton(type: .system)
+    private var localURL: URL?
+
+    init(url: URL) {
+        self.url = url
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        layout()
+        bind()
+        loadFile()
+    }
+
+    private func layout() {
+        view.backgroundColor = UIColor.black.withAlphaComponent(0.95)
+        addChild(previewController)
+        view.addSubview(previewController.view)
+        view.addSubview(bottomView)
+        bottomView.addSubview(saveButton)
+        bottomView.addSubview(shareButton)
+        previewController.didMove(toParent: self)
+        previewController.dataSource = self
+
+        bottomView.backgroundColor = UIColor.black.withAlphaComponent(0.6)
+        saveButton.setTitle("저장", for: .normal)
+        shareButton.setTitle("공유", for: .normal)
+        [saveButton, shareButton].forEach { $0.tintColor = .white }
+
+        previewController.view.snp.makeConstraints { make in
+            make.top.leading.trailing.equalToSuperview()
+            make.bottom.equalTo(bottomView.snp.top)
+        }
+        bottomView.snp.makeConstraints { make in
+            make.leading.trailing.bottom.equalTo(view.safeAreaLayoutGuide)
+            make.height.equalTo(60)
+        }
+        saveButton.snp.makeConstraints { make in
+            make.leading.equalToSuperview().offset(40)
+            make.centerY.equalToSuperview()
+        }
+        shareButton.snp.makeConstraints { make in
+            make.trailing.equalToSuperview().inset(40)
+            make.centerY.equalToSuperview()
+        }
+    }
+
+    private func bind() {
+        saveButton.rx.tap
+            .throttle(.milliseconds(500), scheduler: MainScheduler.instance)
+            .bind { [weak self] in self?.saveFile() }
+            .disposed(by: disposeBag)
+
+        shareButton.rx.tap
+            .throttle(.milliseconds(500), scheduler: MainScheduler.instance)
+            .bind { [weak self] in self?.shareFile() }
+            .disposed(by: disposeBag)
+    }
+
+    private func loadFile() {
+        if url.isFileURL {
+            localURL = url
+            previewController.reloadData()
+        } else {
+            let task = URLSession.shared.downloadTask(with: url) { [weak self] temp, _, _ in
+                guard let self, let temp else { return }
+                self.localURL = temp
+                DispatchQueue.main.async {
+                    self.previewController.reloadData()
+                }
+            }
+            task.resume()
+        }
+    }
+
+    private func saveFile() {
+        guard let localURL else { return }
+        let picker = UIDocumentPickerViewController(forExporting: [localURL])
+        present(picker, animated: true)
+    }
+
+    private func shareFile() {
+        guard let localURL else { return }
+        let activity = UIActivityViewController(activityItems: [localURL], applicationActivities: nil)
+        present(activity, animated: true)
+    }
+}
+
+extension DocumentViewerViewController: QLPreviewControllerDataSource {
+    func numberOfPreviewItems(in controller: QLPreviewController) -> Int {
+        return localURL == nil ? 0 : 1
+    }
+
+    func previewController(_ controller: QLPreviewController, previewItemAt index: Int) -> QLPreviewItem {
+        return localURL! as NSURL
+    }
+}

--- a/chatGPT/Presentation/Scene/ImageViewerViewController.swift
+++ b/chatGPT/Presentation/Scene/ImageViewerViewController.swift
@@ -18,6 +18,9 @@ final class ImageViewerViewController: UIViewController {
     private let imageView = UIImageView()
     private let headerView = UIView()
     private let closeButton = UIButton(type: .system)
+    private let bottomView = UIView()
+    private let saveButton = UIButton(type: .system)
+    private let shareButton = UIButton(type: .system)
 
     init(image: UIImage) {
         self.image = image
@@ -43,15 +46,22 @@ final class ImageViewerViewController: UIViewController {
 
         view.addSubview(scrollView)
         view.addSubview(headerView)
+        view.addSubview(bottomView)
         headerView.addSubview(closeButton)
+        bottomView.addSubview(saveButton)
+        bottomView.addSubview(shareButton)
         scrollView.addSubview(imageView)
 
         imageView.contentMode = .scaleAspectFit
         imageView.image = image
 
         headerView.backgroundColor = UIColor.black.withAlphaComponent(0.6)
+        bottomView.backgroundColor = UIColor.black.withAlphaComponent(0.6)
         closeButton.setImage(UIImage(systemName: "xmark"), for: .normal)
         closeButton.tintColor = .white
+        saveButton.setTitle("저장", for: .normal)
+        shareButton.setTitle("공유", for: .normal)
+        [saveButton, shareButton].forEach { $0.tintColor = .white }
 
         scrollView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
@@ -64,6 +74,19 @@ final class ImageViewerViewController: UIViewController {
 
         closeButton.snp.makeConstraints { make in
             make.trailing.equalToSuperview().inset(16)
+            make.centerY.equalToSuperview()
+        }
+
+        bottomView.snp.makeConstraints { make in
+            make.leading.trailing.bottom.equalTo(view.safeAreaLayoutGuide)
+            make.height.equalTo(60)
+        }
+        saveButton.snp.makeConstraints { make in
+            make.leading.equalToSuperview().offset(40)
+            make.centerY.equalToSuperview()
+        }
+        shareButton.snp.makeConstraints { make in
+            make.trailing.equalToSuperview().inset(40)
             make.centerY.equalToSuperview()
         }
 
@@ -81,6 +104,29 @@ final class ImageViewerViewController: UIViewController {
                 self?.dismiss(animated: true)
             }
             .disposed(by: disposeBag)
+
+        saveButton.rx.tap
+            .throttle(.milliseconds(500), scheduler: MainScheduler.instance)
+            .bind { [weak self] in
+                self?.saveImage()
+            }
+            .disposed(by: disposeBag)
+
+        shareButton.rx.tap
+            .throttle(.milliseconds(500), scheduler: MainScheduler.instance)
+            .bind { [weak self] in
+                self?.shareImage()
+            }
+            .disposed(by: disposeBag)
+    }
+
+    private func saveImage() {
+        UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil)
+    }
+
+    private func shareImage() {
+        let activity = UIActivityViewController(activityItems: [image], applicationActivities: nil)
+        present(activity, animated: true)
     }
 }
 


### PR DESCRIPTION
## Summary
- add bottom overlay with save and share buttons to `ImageViewerViewController`
- implement new `DocumentViewerViewController` for non-image files
- open document viewer from message attachments

## Testing
- `swift test` *(fails: unable to fetch RxSwift due to network restriction)*

------
https://chatgpt.com/codex/tasks/task_e_68876abb87c8832bb905d47ff07d6da7