### PR TITLE
Fix checkerboard overlay order

### DIFF
--- a/chatGPT/Presentation/Scene/ImageViewerViewController.swift
+++ b/chatGPT/Presentation/Scene/ImageViewerViewController.swift
@@ -44,7 +44,7 @@ final class ImageViewerViewController: UIViewController {
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         let rect = AVMakeRect(aspectRatio: image.size, insideRect: imageView.bounds)
-        checkerboardView.frame = rect
+        checkerboardView.frame = imageView.convert(rect, to: scrollView)
     }
 
     private func layout() {
@@ -61,8 +61,8 @@ final class ImageViewerViewController: UIViewController {
         bottomView.addSubview(buttonStack)
         buttonStack.addArrangedSubview(saveButton)
         buttonStack.addArrangedSubview(shareButton)
+        scrollView.addSubview(checkerboardView)
         scrollView.addSubview(imageView)
-        imageView.addSubview(checkerboardView)
 
         imageView.contentMode = .scaleAspectFit
         imageView.image = image


### PR DESCRIPTION
## Summary
- place `CheckerboardView` below `imageView`
- update layout logic so image stays on top

## Testing
- `swift test --enable-code-coverage` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_68879113e92c832b9cf8d4dc2e0a6fc3