### PR TITLE
Implement Korean tokenizer

### DIFF
--- a/chatGPT/Domain/UseCase/UpdateUserPreferenceUseCase.swift
+++ b/chatGPT/Domain/UseCase/UpdateUserPreferenceUseCase.swift
@@ -4,6 +4,7 @@ import RxSwift
 final class UpdateUserPreferenceUseCase {
     private let repository: UserPreferenceRepository
     private let getCurrentUserUseCase: GetCurrentUserUseCase
+    private let tokenizer = KoreanTokenizer()
 
     init(repository: UserPreferenceRepository, getCurrentUserUseCase: GetCurrentUserUseCase) {
         self.repository = repository
@@ -19,8 +20,7 @@ final class UpdateUserPreferenceUseCase {
     }
 
     private func parse(prompt: String) -> [PreferenceItem] {
-        let tokens = prompt.split { $0.isWhitespace || $0.isPunctuation }
-            .map { String($0) }
+        let tokens = tokenizer.nouns(from: prompt)
         var items: [PreferenceItem] = []
         for (index, token) in tokens.enumerated() {
             let time = Date().timeIntervalSince1970

--- a/chatGPT/Domain/Utils/KoreanTokenizer.swift
+++ b/chatGPT/Domain/Utils/KoreanTokenizer.swift
@@ -1,0 +1,38 @@
+import Foundation
+import NaturalLanguage
+
+struct KoreanTokenizer {
+    private let tagger = NLTagger(tagSchemes: [.lexicalClass])
+
+    func nouns(from text: String) -> [String] {
+        tagger.string = text
+        let options: NLTagger.Options = [.omitPunctuation, .omitWhitespace, .omitOther]
+        var tokens: [String] = []
+        tagger.enumerateTags(in: text.startIndex..<text.endIndex, unit: .word, scheme: .lexicalClass, options: options) { tag, range in
+            guard let tag = tag else { return true }
+            if tag == .noun {
+                var token = String(text[range])
+                token = KoreanTokenizer.stripParticle(token)
+                if !token.isEmpty {
+                    tokens.append(token)
+                }
+            }
+            return true
+        }
+        return tokens
+    }
+
+    private static func stripParticle(_ word: String) -> String {
+        let particles = [
+            "은", "는", "이", "가", "을", "를", "에", "에서", "에게", "한테",
+            "도", "으로", "로", "과", "와", "부터", "까지", "마저", "조차", "뿐", "만",
+            "처럼", "보다", "께서"
+        ]
+        for particle in particles {
+            if word.hasSuffix(particle) {
+                return String(word.dropLast(particle.count))
+            }
+        }
+        return word
+    }
+}

--- a/chatGPTTests/UpdateUserPreferenceUseCaseTests.swift
+++ b/chatGPTTests/UpdateUserPreferenceUseCaseTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+import RxSwift
+@testable import chatGPT
+
+final class StubPreferenceRepository: UserPreferenceRepository {
+    private(set) var updatedUid: String?
+    private(set) var updatedItems: [PreferenceItem] = []
+
+    func fetch(uid: String) -> Single<UserPreference?> { .just(nil) }
+
+    func update(uid: String, items: [PreferenceItem]) -> Single<Void> {
+        updatedUid = uid
+        updatedItems = items
+        return .just(())
+    }
+}
+
+final class StubAuthRepository: AuthRepository {
+    var user: AuthUser? = AuthUser(uid: "u1", displayName: nil, photoURL: nil)
+    func observeAuthState() -> Observable<AuthUser?> { .empty() }
+    func currentUser() -> AuthUser? { user }
+    func signOut() throws {}
+}
+
+final class UpdateUserPreferenceUseCaseTests: XCTestCase {
+    private var useCase: UpdateUserPreferenceUseCase!
+    private var repo: StubPreferenceRepository!
+    private var disposeBag: DisposeBag!
+
+    override func setUp() {
+        super.setUp()
+        repo = StubPreferenceRepository()
+        let authRepo = StubAuthRepository()
+        let getUser = GetCurrentUserUseCase(repository: authRepo)
+        useCase = UpdateUserPreferenceUseCase(repository: repo, getCurrentUserUseCase: getUser)
+        disposeBag = DisposeBag()
+    }
+
+    func test_like_sentence() {
+        let prompt = "나는 사과를 좋아해"
+        let exp = expectation(description: "like")
+        useCase.execute(prompt: prompt)
+            .subscribe(onSuccess: { _ in exp.fulfill() })
+            .disposed(by: disposeBag)
+        waitForExpectations(timeout: 1)
+        let item = repo.updatedItems.first
+        XCTAssertEqual(item?.key, "사과")
+        XCTAssertEqual(item?.relation, .like)
+    }
+
+    func test_avoid_sentence_with_particle() {
+        let prompt = "술은 하지마"
+        let exp = expectation(description: "avoid")
+        useCase.execute(prompt: prompt)
+            .subscribe(onSuccess: { _ in exp.fulfill() })
+            .disposed(by: disposeBag)
+        waitForExpectations(timeout: 1)
+        let item = repo.updatedItems.first
+        XCTAssertEqual(item?.key, "술")
+        XCTAssertEqual(item?.relation, .avoid)
+    }
+
+    func test_want_sentence() {
+        let prompt = "콜라 원해"
+        let exp = expectation(description: "want")
+        useCase.execute(prompt: prompt)
+            .subscribe(onSuccess: { _ in exp.fulfill() })
+            .disposed(by: disposeBag)
+        waitForExpectations(timeout: 1)
+        let item = repo.updatedItems.first
+        XCTAssertEqual(item?.key, "콜라")
+        XCTAssertEqual(item?.relation, .want)
+    }
+}


### PR DESCRIPTION
## Summary
- replace whitespace split with `KoreanTokenizer`
- strip particles to keep nouns only
- cover cases with unit tests

## Testing
- `swift test --disable-sandbox` *(fails: could not fetch RxSwift)*

------
https://chatgpt.com/codex/tasks/task_e_6888a9ab26d8832b8de6d721cb7fffba