### PR TITLE
Add preference event history

### DIFF
--- a/chatGPT/Data/FirestorePreferenceEventRepository.swift
+++ b/chatGPT/Data/FirestorePreferenceEventRepository.swift
@@ -1,0 +1,57 @@
+import Foundation
+import FirebaseFirestore
+import RxSwift
+
+final class FirestorePreferenceEventRepository: PreferenceEventRepository {
+    private let db = Firestore.firestore()
+
+    func add(uid: String, events: [PreferenceEvent]) -> Single<Void> {
+        guard !events.isEmpty else { return .just(()) }
+        return Single.create { single in
+            let batch = self.db.batch()
+            let collection = self.db.collection("preferences").document(uid).collection("events")
+            events.forEach { event in
+                let doc = collection.document()
+                let data: [String: Any] = [
+                    "key": event.key,
+                    "relation": event.relation.rawValue,
+                    "timestamp": event.timestamp
+                ]
+                batch.setData(data, forDocument: doc)
+            }
+            batch.commit { error in
+                if let error = error {
+                    single(.failure(error))
+                } else {
+                    single(.success(()))
+                }
+            }
+            return Disposables.create()
+        }
+    }
+
+    func fetch(uid: String) -> Single<[PreferenceEvent]> {
+        Single.create { single in
+            self.db.collection("preferences").document(uid).collection("events").getDocuments { snapshot, error in
+                if let docs = snapshot?.documents {
+                    let events: [PreferenceEvent] = docs.compactMap { doc in
+                        let data = doc.data()
+                        guard
+                            let key = data["key"] as? String,
+                            let raw = data["relation"] as? String,
+                            let relation = PreferenceRelation(rawValue: raw),
+                            let timestamp = data["timestamp"] as? TimeInterval
+                        else { return nil }
+                        return PreferenceEvent(key: key, relation: relation, timestamp: timestamp)
+                    }
+                    single(.success(events))
+                } else if let error = error {
+                    single(.failure(error))
+                } else {
+                    single(.success([]))
+                }
+            }
+            return Disposables.create()
+        }
+    }
+}

--- a/chatGPT/Domain/Entity/PreferenceEvent.swift
+++ b/chatGPT/Domain/Entity/PreferenceEvent.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct PreferenceEvent: Codable {
+    let key: String
+    let relation: PreferenceRelation
+    let timestamp: TimeInterval
+}

--- a/chatGPT/Domain/Repository/PreferenceEventRepository.swift
+++ b/chatGPT/Domain/Repository/PreferenceEventRepository.swift
@@ -1,0 +1,7 @@
+import Foundation
+import RxSwift
+
+protocol PreferenceEventRepository {
+    func add(uid: String, events: [PreferenceEvent]) -> Single<Void>
+    func fetch(uid: String) -> Single<[PreferenceEvent]>
+}

--- a/chatGPT/Domain/UseCase/CalculatePreferenceUseCase.swift
+++ b/chatGPT/Domain/UseCase/CalculatePreferenceUseCase.swift
@@ -1,0 +1,37 @@
+import Foundation
+import RxSwift
+
+final class CalculatePreferenceUseCase {
+    private let eventRepository: PreferenceEventRepository
+    private let getCurrentUserUseCase: GetCurrentUserUseCase
+    private let decay: Double
+
+    init(eventRepository: PreferenceEventRepository,
+         getCurrentUserUseCase: GetCurrentUserUseCase,
+         decay: Double = 0.001) {
+        self.eventRepository = eventRepository
+        self.getCurrentUserUseCase = getCurrentUserUseCase
+        self.decay = decay
+    }
+
+    func execute(top: Int) -> Single<[PreferenceEvent]> {
+        guard let user = getCurrentUserUseCase.execute() else { return .just([]) }
+        return eventRepository.fetch(uid: user.uid)
+            .map { [decay] events in
+                let now = Date().timeIntervalSince1970
+                var scores: [String: Double] = [:]
+                events.forEach { ev in
+                    let key = "\(ev.relation.rawValue):\(ev.key)"
+                    let weight = exp(-decay * (now - ev.timestamp))
+                    scores[key, default: 0] += weight
+                }
+                let sorted = scores.sorted { $0.value > $1.value }.prefix(top)
+                return sorted.map { entry in
+                    let comps = entry.key.split(separator: ":", maxSplits: 1)
+                    let relation = PreferenceRelation(rawValue: String(comps[0]))!
+                    let key = String(comps[1])
+                    return PreferenceEvent(key: key, relation: relation, timestamp: now)
+                }
+            }
+    }
+}

--- a/chatGPT/Presentation/Coordinator/AppCoordinator.swift
+++ b/chatGPT/Presentation/Coordinator/AppCoordinator.swift
@@ -61,12 +61,14 @@ final class AppCoordinator {
         let getCurrentUserUseCase = GetCurrentUserUseCase(repository: authRepository)
         
         let preferenceRepository = FirestoreUserPreferenceRepository()
-        let fetchPreferenceUseCase = FetchUserPreferenceUseCase(
-            repository: preferenceRepository,
+        let eventRepository = FirestorePreferenceEventRepository()
+        let calculatePreferenceUseCase = CalculatePreferenceUseCase(
+            eventRepository: eventRepository,
             getCurrentUserUseCase: getCurrentUserUseCase
         )
         let updatePreferenceUseCase = UpdateUserPreferenceUseCase(
             repository: preferenceRepository,
+            eventRepository: eventRepository,
             getCurrentUserUseCase: getCurrentUserUseCase
         )
         let conversationRepository = FirestoreConversationRepository()
@@ -127,12 +129,10 @@ final class AppCoordinator {
             deleteConversationUseCase: deleteConversationUseCase,
             loadUserImageUseCase: loadUserImageUseCase,
             observeAuthStateUseCase: observeAuthStateUseCase,
-            parseMarkdownUseCase: parseMarkdownUseCase
-        ,
-            fetchPreferenceUseCase: fetchPreferenceUseCase,
+            parseMarkdownUseCase: parseMarkdownUseCase,
+            calculatePreferenceUseCase: calculatePreferenceUseCase,
             updatePreferenceUseCase: updatePreferenceUseCase,
-            uploadFilesUseCase: uploadFilesUseCase
-        ,
+            uploadFilesUseCase: uploadFilesUseCase,
             generateImageUseCase: generateImageUseCase,
             detectImageRequestUseCase: detectImageRequestUseCase
         )

--- a/chatGPT/Presentation/Scene/MainViewController.swift
+++ b/chatGPT/Presentation/Scene/MainViewController.swift
@@ -26,7 +26,7 @@ final class MainViewController: UIViewController {
     private let loadUserImageUseCase: LoadUserProfileImageUseCase
     private let observeAuthStateUseCase: ObserveAuthStateUseCase
     private let parseMarkdownUseCase: ParseMarkdownUseCase
-    private let fetchPreferenceUseCase: FetchUserPreferenceUseCase
+    private let calculatePreferenceUseCase: CalculatePreferenceUseCase
     private let updatePreferenceUseCase: UpdateUserPreferenceUseCase
     private let fetchConversationMessagesUseCase: FetchConversationMessagesUseCase
 
@@ -152,7 +152,7 @@ final class MainViewController: UIViewController {
       loadUserImageUseCase: LoadUserProfileImageUseCase,
       observeAuthStateUseCase: ObserveAuthStateUseCase,
       parseMarkdownUseCase: ParseMarkdownUseCase,
-      fetchPreferenceUseCase: FetchUserPreferenceUseCase,
+      calculatePreferenceUseCase: CalculatePreferenceUseCase,
       updatePreferenceUseCase: UpdateUserPreferenceUseCase,
       uploadFilesUseCase: UploadFilesUseCase,
        generateImageUseCase: GenerateImageUseCase,
@@ -164,7 +164,7 @@ final class MainViewController: UIViewController {
                                            appendMessageUseCase: appendMessageUseCase,
                                            fetchMessagesUseCase: fetchConversationMessagesUseCase,
                                            contextRepository: contextRepository,
-                                           fetchPreferenceUseCase: fetchPreferenceUseCase,
+                                           calculatePreferenceUseCase: calculatePreferenceUseCase,
                                            updatePreferenceUseCase: updatePreferenceUseCase,
                                            uploadFilesUseCase: uploadFilesUseCase,
                                            generateImageUseCase: generateImageUseCase,
@@ -177,7 +177,7 @@ final class MainViewController: UIViewController {
         self.loadUserImageUseCase = loadUserImageUseCase
         self.observeAuthStateUseCase = observeAuthStateUseCase
         self.parseMarkdownUseCase = parseMarkdownUseCase
-        self.fetchPreferenceUseCase = fetchPreferenceUseCase
+        self.calculatePreferenceUseCase = calculatePreferenceUseCase
         self.updatePreferenceUseCase = updatePreferenceUseCase
         super.init(nibName: nil, bundle: nil)
     }


### PR DESCRIPTION
## Summary
- track preference events for history
- compute weighted preference using decay
- adapt view model and coordinator
- update preference tests

## Testing
- `swift test -l` *(fails: unable to access https://github.com/ReactiveX/RxSwift.git)*

------
https://chatgpt.com/codex/tasks/task_e_6888c264755c832b88da5947c19d65db