### PR TITLE
Add user preference tests

### DIFF
--- a/chatGPT/Data/FirestoreUserPreferenceRepository.swift
+++ b/chatGPT/Data/FirestoreUserPreferenceRepository.swift
@@ -3,7 +3,11 @@ import FirebaseFirestore
 import RxSwift
 
 final class FirestoreUserPreferenceRepository: UserPreferenceRepository {
-    private let db = Firestore.firestore()
+    private let db: Firestore
+
+    init(db: Firestore = Firestore.firestore()) {
+        self.db = db
+    }
 
     func fetch(uid: String) -> Single<UserPreference?> {
         Single.create { single in

--- a/chatGPT/Presentation/Scene/ChatViewModel.swift
+++ b/chatGPT/Presentation/Scene/ChatViewModel.swift
@@ -241,9 +241,10 @@ final class ChatViewModel {
             .disposed(by: disposeBag)
     }
     
-    private func preferenceText(from preference: [PreferenceEvent]) -> String? {
+    func preferenceText(from preference: [PreferenceEvent]) -> String? {
         guard !preference.isEmpty else { return nil }
-        let texts = preference.map { "\($0.relation.rawValue): \($0.key)" }
+        let sorted = preference.sorted { $0.timestamp > $1.timestamp }
+        let texts = sorted.prefix(3).map { "\($0.relation.rawValue): \($0.key)" }
         let result = texts.joined(separator: ", ")
         return result.isEmpty ? nil : result
     }

--- a/chatGPTTests/ChatViewModelPreferenceTextTests.swift
+++ b/chatGPTTests/ChatViewModelPreferenceTextTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+import RxSwift
+@testable import chatGPT
+
+// Stub types implementing required protocols
+final class StubSendChatWithContextUseCase {
+    func execute(prompt: String, model: OpenAIModel, stream: Bool, preference: String?, images: [Data], files: [Data], completion: @escaping (Result<String, Error>) -> Void) {}
+    func stream(prompt: String, model: OpenAIModel, preference: String?, images: [Data], files: [Data]) -> Observable<String> { .empty() }
+    func finalize(prompt: String, reply: String, model: OpenAIModel) {}
+}
+
+final class StubSummarizeMessagesUseCase {}
+final class StubSaveConversationUseCase {}
+final class StubAppendMessageUseCase {}
+final class StubFetchConversationMessagesUseCase {}
+final class StubChatContextRepository: ChatContextRepository {
+    var messages: [Message] = []
+    var summary: String? = nil
+    func append(role: RoleType, content: String) {}
+    func updateSummary(_ summary: String) {}
+    func replace(messages: [Message], summary: String?) {}
+    func trim(to maxCount: Int) {}
+    func clear() {}
+}
+final class StubCalculatePreferenceUseCase {}
+final class StubUpdateUserPreferenceUseCase {}
+final class StubUploadFilesUseCase {}
+final class StubGenerateImageUseCase {}
+final class StubDetectImageRequestUseCase {
+    func execute(prompt: String) -> Single<Bool> { .just(false) }
+}
+
+final class ChatViewModelPreferenceTextTests: XCTestCase {
+    func test_preferenceText_sorts_and_truncates() {
+        let vm = ChatViewModel(
+            sendMessageUseCase: StubSendChatWithContextUseCase(),
+            summarizeUseCase: StubSummarizeMessagesUseCase(),
+            saveConversationUseCase: StubSaveConversationUseCase(),
+            appendMessageUseCase: StubAppendMessageUseCase(),
+            fetchMessagesUseCase: StubFetchConversationMessagesUseCase(),
+            contextRepository: StubChatContextRepository(),
+            calculatePreferenceUseCase: StubCalculatePreferenceUseCase(),
+            updatePreferenceUseCase: StubUpdateUserPreferenceUseCase(),
+            uploadFilesUseCase: StubUploadFilesUseCase(),
+            generateImageUseCase: StubGenerateImageUseCase(),
+            detectImageRequestUseCase: StubDetectImageRequestUseCase()
+        )
+        let now = Date().timeIntervalSince1970
+        let events = [
+            PreferenceEvent(key: "banana", relation: .like, timestamp: now - 30),
+            PreferenceEvent(key: "apple", relation: .avoid, timestamp: now - 10),
+            PreferenceEvent(key: "orange", relation: .want, timestamp: now - 20),
+            PreferenceEvent(key: "cake", relation: .like, timestamp: now)
+        ]
+        let text = vm.preferenceText(from: events)
+        XCTAssertEqual(text, "like: cake, avoid: apple, want: orange")
+    }
+}

--- a/chatGPTTests/FirebaseFirestoreStubs.swift
+++ b/chatGPTTests/FirebaseFirestoreStubs.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+class Firestore {
+    var lastBatch: WriteBatch?
+    func batch() -> WriteBatch { let b = WriteBatch(); lastBatch = b; return b }
+    func collection(_ path: String) -> CollectionReference { CollectionReference(path: path) }
+    static func firestore() -> Firestore { Firestore() }
+}
+
+class CollectionReference {
+    let path: String
+    init(path: String) { self.path = path }
+    func document(_ id: String) -> DocumentReference { DocumentReference(path: "\(path)/\(id)") }
+    func collection(_ id: String) -> CollectionReference { CollectionReference(path: "\(path)/\(id)") }
+}
+
+class DocumentReference {
+    let path: String
+    init(path: String) { self.path = path }
+}
+
+class WriteBatch {
+    struct SetCall { let data: [String: Any]; let document: DocumentReference; let merge: Bool }
+    var setCalls: [SetCall] = []
+    func setData(_ data: [String: Any], forDocument document: DocumentReference, merge: Bool) {
+        setCalls.append(SetCall(data: data, document: document, merge: merge))
+    }
+    func commit(completion: ((Error?) -> Void)? = nil) { completion?(nil) }
+}
+
+class FieldValue {
+    static func increment(_ value: Int64) -> Int64 { value }
+}

--- a/chatGPTTests/FirestoreUserPreferenceRepositoryTests.swift
+++ b/chatGPTTests/FirestoreUserPreferenceRepositoryTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+import RxSwift
+@testable import chatGPT
+
+// MARK: - Tests
+final class FirestoreUserPreferenceRepositoryTests: XCTestCase {
+    private var disposeBag: DisposeBag!
+
+    override func setUp() {
+        super.setUp()
+        disposeBag = DisposeBag()
+    }
+
+    func test_update_writes_data() {
+        let firestore = Firestore()
+        let repository = FirestoreUserPreferenceRepository(db: firestore)
+        let now = Date().timeIntervalSince1970
+        let item = PreferenceItem(key: "apple", relation: .like, updatedAt: now, count: 1)
+        let exp = expectation(description: "update")
+        repository.update(uid: "u1", items: [item])
+            .subscribe(onSuccess: { exp.fulfill() })
+            .disposed(by: disposeBag)
+        waitForExpectations(timeout: 1)
+        let call = firestore.lastBatch?.setCalls.first
+        XCTAssertEqual(call?.document.path, "preferences/u1/items/apple_like")
+        XCTAssertEqual(call?.data["key"] as? String, "apple")
+        XCTAssertEqual(call?.data["relation"] as? String, "like")
+        XCTAssertEqual(call?.data["updatedAt"] as? TimeInterval, now)
+    }
+}

--- a/chatGPTTests/UpdateUserPreferenceUseCaseTests.swift
+++ b/chatGPTTests/UpdateUserPreferenceUseCaseTests.swift
@@ -123,4 +123,47 @@ final class UpdateUserPreferenceUseCaseTests: XCTestCase {
         XCTAssertEqual(item?.key, "apples")
         XCTAssertEqual(item?.relation, .like)
     }
+
+    func test_parse_multiple_relations_in_sentence() {
+        let prompt = "I like apples but dislike bananas"
+        let exp = expectation(description: "multi")
+        useCase.execute(prompt: prompt)
+            .subscribe(onSuccess: { _ in exp.fulfill() })
+            .disposed(by: disposeBag)
+        waitForExpectations(timeout: 1)
+        XCTAssertEqual(repo.updatedItems.count, 2)
+        XCTAssertEqual(repo.updatedItems[0].relation, .like)
+        XCTAssertEqual(repo.updatedItems[0].key, "apples")
+        XCTAssertEqual(repo.updatedItems[1].relation, .dislike)
+        XCTAssertEqual(repo.updatedItems[1].key, "bananas")
+    }
+
+    func test_parse_korean_sentence() {
+        translator.mapping["사과 좋아하고 맥주 피하고 싶어"] = "like apple avoid beer"
+        let prompt = "사과 좋아하고 맥주 피하고 싶어"
+        let exp = expectation(description: "korean")
+        useCase.execute(prompt: prompt)
+            .subscribe(onSuccess: { _ in exp.fulfill() })
+            .disposed(by: disposeBag)
+        waitForExpectations(timeout: 1)
+        XCTAssertEqual(repo.updatedItems.count, 2)
+        XCTAssertEqual(repo.updatedItems[0].relation, .like)
+        XCTAssertEqual(repo.updatedItems[0].key, "apple")
+        XCTAssertEqual(repo.updatedItems[1].relation, .avoid)
+        XCTAssertEqual(repo.updatedItems[1].key, "beer")
+    }
+
+    func test_parse_with_punctuation_and_case() {
+        let prompt = "LIKE Pizza, AVOID Broccoli!"
+        let exp = expectation(description: "punctuation")
+        useCase.execute(prompt: prompt)
+            .subscribe(onSuccess: { _ in exp.fulfill() })
+            .disposed(by: disposeBag)
+        waitForExpectations(timeout: 1)
+        XCTAssertEqual(repo.updatedItems.count, 2)
+        XCTAssertEqual(repo.updatedItems[0].key, "pizza")
+        XCTAssertEqual(repo.updatedItems[0].relation, .like)
+        XCTAssertEqual(repo.updatedItems[1].key, "broccoli")
+        XCTAssertEqual(repo.updatedItems[1].relation, .avoid)
+    }
 }


### PR DESCRIPTION
## Summary
- inject Firestore into FirestoreUserPreferenceRepository
- sort and truncate preferenceText output
- cover parsing of UpdateUserPreferenceUseCase with diverse examples
- verify FirestoreUserPreferenceRepository updates correct data
- test ChatViewModel preference text formatting

## Testing
- `swift test -l` *(fails: unable to fetch RxSwift)*

------
https://chatgpt.com/codex/tasks/task_e_6888c987a444832bab41a8f17a6a9b20