### PR TITLE
Add preference status tracking

### DIFF
--- a/chatGPT/Data/FirestorePreferenceStatusRepository.swift
+++ b/chatGPT/Data/FirestorePreferenceStatusRepository.swift
@@ -1,0 +1,67 @@
+import Foundation
+import FirebaseFirestore
+import RxSwift
+
+final class FirestorePreferenceStatusRepository: PreferenceStatusRepository {
+    private let db = Firestore.firestore()
+
+    func fetch(uid: String) -> Single<[PreferenceStatus]> {
+        Single.create { single in
+            self.db.collection("preferences").document(uid).collection("status").getDocuments { snapshot, error in
+                if let docs = snapshot?.documents {
+                    let statuses: [PreferenceStatus] = docs.compactMap { doc in
+                        let data = doc.data()
+                        guard
+                            let key = data["key"] as? String,
+                            let raw = data["currentRelation"] as? String,
+                            let relation = PreferenceRelation(rawValue: raw),
+                            let updatedAt = data["updatedAt"] as? TimeInterval
+                        else { return nil }
+                        let prevRaw = data["previousRelation"] as? String
+                        let prev = prevRaw.flatMap { PreferenceRelation(rawValue: $0) }
+                        let changedAt = data["changedAt"] as? TimeInterval
+                        return PreferenceStatus(key: key,
+                                                currentRelation: relation,
+                                                updatedAt: updatedAt,
+                                                previousRelation: prev,
+                                                changedAt: changedAt)
+                    }
+                    single(.success(statuses))
+                } else if let error = error {
+                    single(.failure(error))
+                } else {
+                    single(.success([]))
+                }
+            }
+            return Disposables.create()
+        }
+    }
+
+    func update(uid: String, status: PreferenceStatus) -> Single<Void> {
+        Single.create { single in
+            let doc = self.db.collection("preferences")
+                .document(uid)
+                .collection("status")
+                .document(status.key)
+            var data: [String: Any] = [
+                "key": status.key,
+                "currentRelation": status.currentRelation.rawValue,
+                "updatedAt": status.updatedAt
+            ]
+            if let prev = status.previousRelation {
+                data["previousRelation"] = prev.rawValue
+            }
+            if let changed = status.changedAt {
+                data["changedAt"] = changed
+            }
+            doc.setData(data, merge: true) { error in
+                if let error = error {
+                    single(.failure(error))
+                } else {
+                    single(.success(()))
+                }
+            }
+            return Disposables.create()
+        }
+    }
+}

--- a/chatGPT/Domain/Entity/PreferenceStatus.swift
+++ b/chatGPT/Domain/Entity/PreferenceStatus.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct PreferenceStatus: Codable {
+    let key: String
+    var currentRelation: PreferenceRelation
+    var updatedAt: TimeInterval
+    var previousRelation: PreferenceRelation?
+    var changedAt: TimeInterval?
+}

--- a/chatGPT/Domain/Repository/PreferenceStatusRepository.swift
+++ b/chatGPT/Domain/Repository/PreferenceStatusRepository.swift
@@ -1,0 +1,7 @@
+import Foundation
+import RxSwift
+
+protocol PreferenceStatusRepository {
+    func fetch(uid: String) -> Single<[PreferenceStatus]>
+    func update(uid: String, status: PreferenceStatus) -> Single<Void>
+}


### PR DESCRIPTION
## Summary
- add PreferenceStatus entity
- implement PreferenceStatusRepository protocol and Firestore version
- track previous relation in UpdateUserPreferenceUseCase
- update tests for new dependency

## Testing
- `swift test` *(fails: unable to fetch RxSwift)*

------
https://chatgpt.com/codex/tasks/task_e_6888e22c088c832b9904cf560035fbd7