### PR TITLE
Add preference history view

### DIFF
--- a/chatGPT.xcodeproj/project.pbxproj
+++ b/chatGPT.xcodeproj/project.pbxproj
@@ -140,9 +140,15 @@
 		a0d99ba381b44d72b54327f6 /* MenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = e9d37b25c97b401d97ce1732 /* MenuViewController.swift */; };
 		aa711a251b034678b1e8a5c7 /* KingfisherImageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7d4726864e6840b090b6e407 /* KingfisherImageRepository.swift */; };
 		c076797f219e4afdb2928170 /* SummarizeMessagesUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = ee987c883dab481cb2765061 /* SummarizeMessagesUseCase.swift */; };
-		ccfa5907f1434e87b23a8d58 /* SendChatWithContextUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = f495b15056fc494682c60df5 /* SendChatWithContextUseCase.swift */; };
-		d4ae3188874b4ea4a0abdef2 /* ObserveAuthStateUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9b8f82223d524f878b330338 /* ObserveAuthStateUseCase.swift */; };
-		edab8d1cb29b4a0d8fc109d2 /* ObserveConversationsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3e924cb7e10d40a1a28fc225 /* ObserveConversationsUseCase.swift */; };
+                ccfa5907f1434e87b23a8d58 /* SendChatWithContextUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = f495b15056fc494682c60df5 /* SendChatWithContextUseCase.swift */; };
+                d4ae3188874b4ea4a0abdef2 /* ObserveAuthStateUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9b8f82223d524f878b330338 /* ObserveAuthStateUseCase.swift */; };
+                edab8d1cb29b4a0d8fc109d2 /* ObserveConversationsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3e924cb7e10d40a1a28fc225 /* ObserveConversationsUseCase.swift */; };
+                2C81557F25F64DF8A4771CF5 /* FetchPreferenceEventsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D0B906B8B645D2BD138DD4 /* FetchPreferenceEventsUseCase.swift */; };
+                348D57FA354A44F6B99CF055 /* FetchPreferenceStatusUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8A68DEFEA04987AB0B477C /* FetchPreferenceStatusUseCase.swift */; };
+                1901B412C30245A888727020 /* UpdatePreferenceStatusUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C8A7A046A9642F6B9514D69 /* UpdatePreferenceStatusUseCase.swift */; };
+                B15B84C1F6164CD98F4EB210 /* DeletePreferenceEventUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D3B6E04199F46D0A56DC79A /* DeletePreferenceEventUseCase.swift */; };
+                F36794FCCDC145948E5611EB /* DeletePreferenceStatusUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 550E777D116C4DD6AA8FDB92 /* DeletePreferenceStatusUseCase.swift */; };
+                612B81605F45468EA3B3EDEE /* PreferenceHistoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66C4A0471F754726A0976FCD /* PreferenceHistoryViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -290,7 +296,13 @@
 		e9d37b25c97b401d97ce1732 /* MenuViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuViewController.swift; sourceTree = "<group>"; };
 		ee987c883dab481cb2765061 /* SummarizeMessagesUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummarizeMessagesUseCase.swift; sourceTree = "<group>"; };
 		eef3624df55348a684cdc5fd /* LoadUserProfileImageUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadUserProfileImageUseCase.swift; sourceTree = "<group>"; };
-		f495b15056fc494682c60df5 /* SendChatWithContextUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendChatWithContextUseCase.swift; sourceTree = "<group>"; };
+                f495b15056fc494682c60df5 /* SendChatWithContextUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendChatWithContextUseCase.swift; sourceTree = "<group>"; };
+                94D0B906B8B645D2BD138DD4 /* FetchPreferenceEventsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchPreferenceEventsUseCase.swift; sourceTree = "<group>"; };
+                3F8A68DEFEA04987AB0B477C /* FetchPreferenceStatusUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchPreferenceStatusUseCase.swift; sourceTree = "<group>"; };
+                0C8A7A046A9642F6B9514D69 /* UpdatePreferenceStatusUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePreferenceStatusUseCase.swift; sourceTree = "<group>"; };
+                8D3B6E04199F46D0A56DC79A /* DeletePreferenceEventUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeletePreferenceEventUseCase.swift; sourceTree = "<group>"; };
+                550E777D116C4DD6AA8FDB92 /* DeletePreferenceStatusUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeletePreferenceStatusUseCase.swift; sourceTree = "<group>"; };
+                66C4A0471F754726A0976FCD /* PreferenceHistoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferenceHistoryViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -530,12 +542,17 @@
 				79766A3D81B253405488FCA1 /* AppendMessageUseCase.swift */,
 				F20000032F00000300000003 /* UploadFilesUseCase.swift */,
 				3e924cb7e10d40a1a28fc225 /* ObserveConversationsUseCase.swift */,
-				D1429C4B96A13E73C35752E4 /* UpdateConversationTitleUseCase.swift */,
-				64EB7DD9103C65295FB89E7C /* DeleteConversationUseCase.swift */,
-			);
-			path = UseCase;
-			sourceTree = "<group>";
-		};
+                                D1429C4B96A13E73C35752E4 /* UpdateConversationTitleUseCase.swift */,
+                                64EB7DD9103C65295FB89E7C /* DeleteConversationUseCase.swift */,
+                                94D0B906B8B645D2BD138DD4 /* FetchPreferenceEventsUseCase.swift */,
+                                3F8A68DEFEA04987AB0B477C /* FetchPreferenceStatusUseCase.swift */,
+                                0C8A7A046A9642F6B9514D69 /* UpdatePreferenceStatusUseCase.swift */,
+                                8D3B6E04199F46D0A56DC79A /* DeletePreferenceEventUseCase.swift */,
+                                550E777D116C4DD6AA8FDB92 /* DeletePreferenceStatusUseCase.swift */,
+                        );
+                        path = UseCase;
+                        sourceTree = "<group>";
+                };
 		F1DF3B122DF9B07800D8445A /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
@@ -563,8 +580,9 @@
 				e9d37b25c97b401d97ce1732 /* MenuViewController.swift */,
 				F117E07A2E0188F200D1C95F /* ChatViewModel.swift */,
 				F1D52BC22E266CCF00239002 /* ImageViewerViewController.swift */,
-				F10E27FD2E37A6AA00F3821A /* DocumentViewerViewController.swift */,
-				F117E07C2E018AF400D1C95F /* Cells */,
+                                F10E27FD2E37A6AA00F3821A /* DocumentViewerViewController.swift */,
+                                66C4A0471F754726A0976FCD /* PreferenceHistoryViewController.swift */,
+                                F117E07C2E018AF400D1C95F /* Cells */,
 			);
 			path = Scene;
 			sourceTree = "<group>";
@@ -887,9 +905,15 @@
 				F1DF3B182DF9B0E100D8445A /* APIKeyInputViewController.swift in Sources */,
 				F122E5D42E0C0352006E81DD /* FetchConversationMessagesUseCase.swift in Sources */,
 				F1BFC8372E38FF9400FF3DA6 /* TranslationRepository.swift in Sources */,
-				FDF214A9E94D3F7E2DA0DEED /* UpdateConversationTitleUseCase.swift in Sources */,
-				679ABD2960C6FE51CF51C1D7 /* DeleteConversationUseCase.swift in Sources */,
-			);
+                                FDF214A9E94D3F7E2DA0DEED /* UpdateConversationTitleUseCase.swift in Sources */,
+                                679ABD2960C6FE51CF51C1D7 /* DeleteConversationUseCase.swift in Sources */,
+                                2C81557F25F64DF8A4771CF5 /* FetchPreferenceEventsUseCase.swift in Sources */,
+                                348D57FA354A44F6B99CF055 /* FetchPreferenceStatusUseCase.swift in Sources */,
+                                1901B412C30245A888727020 /* UpdatePreferenceStatusUseCase.swift in Sources */,
+                                B15B84C1F6164CD98F4EB210 /* DeletePreferenceEventUseCase.swift in Sources */,
+                                F36794FCCDC145948E5611EB /* DeletePreferenceStatusUseCase.swift in Sources */,
+                                612B81605F45468EA3B3EDEE /* PreferenceHistoryViewController.swift in Sources */,
+                        );
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		F16563DA2DF9A310001CDF3B /* Sources */ = {

--- a/chatGPT/Data/FirestorePreferenceEventRepository.swift
+++ b/chatGPT/Data/FirestorePreferenceEventRepository.swift
@@ -42,7 +42,10 @@ final class FirestorePreferenceEventRepository: PreferenceEventRepository {
                             let relation = PreferenceRelation(rawValue: raw),
                             let timestamp = data["timestamp"] as? TimeInterval
                         else { return nil }
-                        return PreferenceEvent(key: key, relation: relation, timestamp: timestamp)
+                        return PreferenceEvent(id: doc.documentID,
+                                               key: key,
+                                               relation: relation,
+                                               timestamp: timestamp)
                     }
                     single(.success(events))
                 } else if let error = error {
@@ -51,6 +54,23 @@ final class FirestorePreferenceEventRepository: PreferenceEventRepository {
                     single(.success([]))
                 }
             }
+            return Disposables.create()
+        }
+    }
+
+    func delete(uid: String, eventID: String) -> Single<Void> {
+        Single.create { single in
+            self.db.collection("preferences")
+                .document(uid)
+                .collection("events")
+                .document(eventID)
+                .delete { error in
+                    if let error = error {
+                        single(.failure(error))
+                    } else {
+                        single(.success(()))
+                    }
+                }
             return Disposables.create()
         }
     }

--- a/chatGPT/Data/FirestorePreferenceStatusRepository.swift
+++ b/chatGPT/Data/FirestorePreferenceStatusRepository.swift
@@ -71,4 +71,21 @@ final class FirestorePreferenceStatusRepository: PreferenceStatusRepository {
             return Disposables.create()
         }
     }
+
+    func delete(uid: String, key: String) -> Single<Void> {
+        Single.create { single in
+            self.db.collection("preferences")
+                .document(uid)
+                .collection("status")
+                .document(key)
+                .delete { error in
+                    if let error = error {
+                        single(.failure(error))
+                    } else {
+                        single(.success(()))
+                    }
+                }
+            return Disposables.create()
+        }
+    }
 }

--- a/chatGPT/Domain/Entity/PreferenceEvent.swift
+++ b/chatGPT/Domain/Entity/PreferenceEvent.swift
@@ -1,7 +1,15 @@
 import Foundation
 
 struct PreferenceEvent: Codable {
+    var id: String?
     let key: String
     let relation: PreferenceRelation
     let timestamp: TimeInterval
+
+    init(id: String? = nil, key: String, relation: PreferenceRelation, timestamp: TimeInterval) {
+        self.id = id
+        self.key = key
+        self.relation = relation
+        self.timestamp = timestamp
+    }
 }

--- a/chatGPT/Domain/Repository/PreferenceEventRepository.swift
+++ b/chatGPT/Domain/Repository/PreferenceEventRepository.swift
@@ -4,4 +4,5 @@ import RxSwift
 protocol PreferenceEventRepository {
     func add(uid: String, events: [PreferenceEvent]) -> Single<Void>
     func fetch(uid: String) -> Single<[PreferenceEvent]>
+    func delete(uid: String, eventID: String) -> Single<Void>
 }

--- a/chatGPT/Domain/Repository/PreferenceStatusRepository.swift
+++ b/chatGPT/Domain/Repository/PreferenceStatusRepository.swift
@@ -4,4 +4,5 @@ import RxSwift
 protocol PreferenceStatusRepository {
     func fetch(uid: String) -> Single<[PreferenceStatus]>
     func update(uid: String, status: PreferenceStatus) -> Single<Void>
+    func delete(uid: String, key: String) -> Single<Void>
 }

--- a/chatGPT/Domain/UseCase/DeletePreferenceEventUseCase.swift
+++ b/chatGPT/Domain/UseCase/DeletePreferenceEventUseCase.swift
@@ -1,0 +1,20 @@
+import Foundation
+import RxSwift
+
+final class DeletePreferenceEventUseCase {
+    private let repository: PreferenceEventRepository
+    private let getCurrentUserUseCase: GetCurrentUserUseCase
+
+    init(repository: PreferenceEventRepository,
+         getCurrentUserUseCase: GetCurrentUserUseCase) {
+        self.repository = repository
+        self.getCurrentUserUseCase = getCurrentUserUseCase
+    }
+
+    func execute(eventID: String) -> Single<Void> {
+        guard let user = getCurrentUserUseCase.execute() else {
+            return .error(PreferenceError.noUser)
+        }
+        return repository.delete(uid: user.uid, eventID: eventID)
+    }
+}

--- a/chatGPT/Domain/UseCase/DeletePreferenceStatusUseCase.swift
+++ b/chatGPT/Domain/UseCase/DeletePreferenceStatusUseCase.swift
@@ -1,0 +1,20 @@
+import Foundation
+import RxSwift
+
+final class DeletePreferenceStatusUseCase {
+    private let repository: PreferenceStatusRepository
+    private let getCurrentUserUseCase: GetCurrentUserUseCase
+
+    init(repository: PreferenceStatusRepository,
+         getCurrentUserUseCase: GetCurrentUserUseCase) {
+        self.repository = repository
+        self.getCurrentUserUseCase = getCurrentUserUseCase
+    }
+
+    func execute(key: String) -> Single<Void> {
+        guard let user = getCurrentUserUseCase.execute() else {
+            return .error(PreferenceError.noUser)
+        }
+        return repository.delete(uid: user.uid, key: key)
+    }
+}

--- a/chatGPT/Domain/UseCase/FetchPreferenceEventsUseCase.swift
+++ b/chatGPT/Domain/UseCase/FetchPreferenceEventsUseCase.swift
@@ -1,0 +1,20 @@
+import Foundation
+import RxSwift
+
+final class FetchPreferenceEventsUseCase {
+    private let repository: PreferenceEventRepository
+    private let getCurrentUserUseCase: GetCurrentUserUseCase
+
+    init(repository: PreferenceEventRepository,
+         getCurrentUserUseCase: GetCurrentUserUseCase) {
+        self.repository = repository
+        self.getCurrentUserUseCase = getCurrentUserUseCase
+    }
+
+    func execute() -> Single<[PreferenceEvent]> {
+        guard let user = getCurrentUserUseCase.execute() else {
+            return .just([])
+        }
+        return repository.fetch(uid: user.uid)
+    }
+}

--- a/chatGPT/Domain/UseCase/FetchPreferenceStatusUseCase.swift
+++ b/chatGPT/Domain/UseCase/FetchPreferenceStatusUseCase.swift
@@ -1,0 +1,20 @@
+import Foundation
+import RxSwift
+
+final class FetchPreferenceStatusUseCase {
+    private let repository: PreferenceStatusRepository
+    private let getCurrentUserUseCase: GetCurrentUserUseCase
+
+    init(repository: PreferenceStatusRepository,
+         getCurrentUserUseCase: GetCurrentUserUseCase) {
+        self.repository = repository
+        self.getCurrentUserUseCase = getCurrentUserUseCase
+    }
+
+    func execute() -> Single<[PreferenceStatus]> {
+        guard let user = getCurrentUserUseCase.execute() else {
+            return .just([])
+        }
+        return repository.fetch(uid: user.uid)
+    }
+}

--- a/chatGPT/Domain/UseCase/UpdatePreferenceStatusUseCase.swift
+++ b/chatGPT/Domain/UseCase/UpdatePreferenceStatusUseCase.swift
@@ -1,0 +1,20 @@
+import Foundation
+import RxSwift
+
+final class UpdatePreferenceStatusUseCase {
+    private let repository: PreferenceStatusRepository
+    private let getCurrentUserUseCase: GetCurrentUserUseCase
+
+    init(repository: PreferenceStatusRepository,
+         getCurrentUserUseCase: GetCurrentUserUseCase) {
+        self.repository = repository
+        self.getCurrentUserUseCase = getCurrentUserUseCase
+    }
+
+    func execute(status: PreferenceStatus) -> Single<Void> {
+        guard let user = getCurrentUserUseCase.execute() else {
+            return .error(PreferenceError.noUser)
+        }
+        return repository.update(uid: user.uid, status: status)
+    }
+}

--- a/chatGPT/Presentation/Coordinator/AppCoordinator.swift
+++ b/chatGPT/Presentation/Coordinator/AppCoordinator.swift
@@ -75,6 +75,26 @@ final class AppCoordinator {
             getCurrentUserUseCase: getCurrentUserUseCase,
             translationRepository: translationRepository
         )
+        let fetchPreferenceEventsUseCase = FetchPreferenceEventsUseCase(
+            repository: eventRepository,
+            getCurrentUserUseCase: getCurrentUserUseCase
+        )
+        let fetchPreferenceStatusUseCase = FetchPreferenceStatusUseCase(
+            repository: statusRepository,
+            getCurrentUserUseCase: getCurrentUserUseCase
+        )
+        let updatePreferenceStatusUseCase = UpdatePreferenceStatusUseCase(
+            repository: statusRepository,
+            getCurrentUserUseCase: getCurrentUserUseCase
+        )
+        let deletePreferenceEventUseCase = DeletePreferenceEventUseCase(
+            repository: eventRepository,
+            getCurrentUserUseCase: getCurrentUserUseCase
+        )
+        let deletePreferenceStatusUseCase = DeletePreferenceStatusUseCase(
+            repository: statusRepository,
+            getCurrentUserUseCase: getCurrentUserUseCase
+        )
         let conversationRepository = FirestoreConversationRepository()
         
         let saveConversationUseCase = SaveConversationUseCase(
@@ -138,7 +158,12 @@ final class AppCoordinator {
             updatePreferenceUseCase: updatePreferenceUseCase,
             uploadFilesUseCase: uploadFilesUseCase,
             generateImageUseCase: generateImageUseCase,
-            detectImageRequestUseCase: detectImageRequestUseCase
+            detectImageRequestUseCase: detectImageRequestUseCase,
+            fetchPreferenceEventsUseCase: fetchPreferenceEventsUseCase,
+            fetchPreferenceStatusUseCase: fetchPreferenceStatusUseCase,
+            updatePreferenceStatusUseCase: updatePreferenceStatusUseCase,
+            deletePreferenceEventUseCase: deletePreferenceEventUseCase,
+            deletePreferenceStatusUseCase: deletePreferenceStatusUseCase
         )
         
         let nav = UINavigationController(rootViewController: vc)

--- a/chatGPT/Presentation/Scene/MainViewController.swift
+++ b/chatGPT/Presentation/Scene/MainViewController.swift
@@ -29,6 +29,11 @@ final class MainViewController: UIViewController {
     private let calculatePreferenceUseCase: CalculatePreferenceUseCase
     private let updatePreferenceUseCase: UpdateUserPreferenceUseCase
     private let fetchConversationMessagesUseCase: FetchConversationMessagesUseCase
+    private let fetchPreferenceEventsUseCase: FetchPreferenceEventsUseCase
+    private let fetchPreferenceStatusUseCase: FetchPreferenceStatusUseCase
+    private let updatePreferenceStatusUseCase: UpdatePreferenceStatusUseCase
+    private let deletePreferenceEventUseCase: DeletePreferenceEventUseCase
+    private let deletePreferenceStatusUseCase: DeletePreferenceStatusUseCase
 
     private let disposeBag = DisposeBag()
 
@@ -73,6 +78,11 @@ final class MainViewController: UIViewController {
             updateTitleUseCase: updateTitleUseCase,
             deleteConversationUseCase: deleteConversationUseCase,
             fetchMessagesUseCase: fetchConversationMessagesUseCase,
+            fetchEventsUseCase: fetchPreferenceEventsUseCase,
+            fetchStatusUseCase: fetchPreferenceStatusUseCase,
+            updateStatusUseCase: updatePreferenceStatusUseCase,
+            deleteEventUseCase: deletePreferenceEventUseCase,
+            deleteStatusUseCase: deletePreferenceStatusUseCase,
             selectedModel: selectedModel,
             streamEnabled: streamEnabled,
             currentConversationID: chatViewModel.conversationID,
@@ -156,7 +166,12 @@ final class MainViewController: UIViewController {
       updatePreferenceUseCase: UpdateUserPreferenceUseCase,
       uploadFilesUseCase: UploadFilesUseCase,
        generateImageUseCase: GenerateImageUseCase,
-       detectImageRequestUseCase: DetectImageRequestUseCase) {
+      detectImageRequestUseCase: DetectImageRequestUseCase,
+      fetchPreferenceEventsUseCase: FetchPreferenceEventsUseCase,
+      fetchPreferenceStatusUseCase: FetchPreferenceStatusUseCase,
+      updatePreferenceStatusUseCase: UpdatePreferenceStatusUseCase,
+      deletePreferenceEventUseCase: DeletePreferenceEventUseCase,
+      deletePreferenceStatusUseCase: DeletePreferenceStatusUseCase) {
         self.fetchModelsUseCase = fetchModelsUseCase
        self.chatViewModel = ChatViewModel(sendMessageUseCase: sendChatMessageUseCase,
                                            summarizeUseCase: summarizeUseCase,
@@ -179,6 +194,11 @@ final class MainViewController: UIViewController {
         self.parseMarkdownUseCase = parseMarkdownUseCase
         self.calculatePreferenceUseCase = calculatePreferenceUseCase
         self.updatePreferenceUseCase = updatePreferenceUseCase
+        self.fetchPreferenceEventsUseCase = fetchPreferenceEventsUseCase
+        self.fetchPreferenceStatusUseCase = fetchPreferenceStatusUseCase
+        self.updatePreferenceStatusUseCase = updatePreferenceStatusUseCase
+        self.deletePreferenceEventUseCase = deletePreferenceEventUseCase
+        self.deletePreferenceStatusUseCase = deletePreferenceStatusUseCase
         super.init(nibName: nil, bundle: nil)
     }
     

--- a/chatGPT/Presentation/Scene/MenuViewController.swift
+++ b/chatGPT/Presentation/Scene/MenuViewController.swift
@@ -27,6 +27,11 @@ final class MenuViewController: UIViewController {
     private let updateTitleUseCase: UpdateConversationTitleUseCase
     private let deleteConversationUseCase: DeleteConversationUseCase
     private let fetchMessagesUseCase: FetchConversationMessagesUseCase
+    private let fetchEventsUseCase: FetchPreferenceEventsUseCase
+    private let fetchStatusUseCase: FetchPreferenceStatusUseCase
+    private let updateStatusUseCase: UpdatePreferenceStatusUseCase
+    private let deleteEventUseCase: DeletePreferenceEventUseCase
+    private let deleteStatusUseCase: DeletePreferenceStatusUseCase
     private var currentConversationID: String?
     private let draftExists: Bool
     private let disposeBag = DisposeBag()
@@ -64,6 +69,11 @@ final class MenuViewController: UIViewController {
          updateTitleUseCase: UpdateConversationTitleUseCase,
          deleteConversationUseCase: DeleteConversationUseCase,
          fetchMessagesUseCase: FetchConversationMessagesUseCase,
+         fetchEventsUseCase: FetchPreferenceEventsUseCase,
+         fetchStatusUseCase: FetchPreferenceStatusUseCase,
+         updateStatusUseCase: UpdatePreferenceStatusUseCase,
+         deleteEventUseCase: DeletePreferenceEventUseCase,
+         deleteStatusUseCase: DeletePreferenceStatusUseCase,
          selectedModel: OpenAIModel,
          streamEnabled: Bool,
          currentConversationID: String?,
@@ -76,6 +86,11 @@ final class MenuViewController: UIViewController {
         self.updateTitleUseCase = updateTitleUseCase
         self.deleteConversationUseCase = deleteConversationUseCase
         self.fetchMessagesUseCase = fetchMessagesUseCase
+        self.fetchEventsUseCase = fetchEventsUseCase
+        self.fetchStatusUseCase = fetchStatusUseCase
+        self.updateStatusUseCase = updateStatusUseCase
+        self.deleteEventUseCase = deleteEventUseCase
+        self.deleteStatusUseCase = deleteStatusUseCase
         self.selectedModel = selectedModel
         self.streamEnabled = streamEnabled
         self.currentConversationID = currentConversationID
@@ -120,7 +135,14 @@ final class MenuViewController: UIViewController {
                             cell.showMenu()
                         }
                     } else if indexPath.row == 1 {
-                        return
+                        let prefVC = PreferenceHistoryViewController(
+                            fetchEventsUseCase: self.fetchEventsUseCase,
+                            fetchStatusUseCase: self.fetchStatusUseCase,
+                            updateStatusUseCase: self.updateStatusUseCase,
+                            deleteEventUseCase: self.deleteEventUseCase,
+                            deleteStatusUseCase: self.deleteStatusUseCase
+                        )
+                        self.present(prefVC, animated: true)
                     }
                 case .history:
                     let convo = self.conversations[indexPath.row]

--- a/chatGPT/Presentation/Scene/PreferenceHistoryViewController.swift
+++ b/chatGPT/Presentation/Scene/PreferenceHistoryViewController.swift
@@ -1,0 +1,189 @@
+import UIKit
+import SnapKit
+import RxSwift
+import RxCocoa
+
+final class PreferenceHistoryViewController: UIViewController {
+    private enum Section: Int, CaseIterable {
+        case status
+        case history
+
+        var title: String {
+            switch self {
+            case .status: return "현재 상태"
+            case .history: return "기록"
+            }
+        }
+    }
+
+    private let fetchEventsUseCase: FetchPreferenceEventsUseCase
+    private let fetchStatusUseCase: FetchPreferenceStatusUseCase
+    private let updateStatusUseCase: UpdatePreferenceStatusUseCase
+    private let deleteEventUseCase: DeletePreferenceEventUseCase
+    private let deleteStatusUseCase: DeletePreferenceStatusUseCase
+    private let disposeBag = DisposeBag()
+
+    private let tableView = UITableView(frame: .zero, style: .grouped)
+    private let events = BehaviorRelay<[PreferenceEvent]>(value: [])
+    private let statuses = BehaviorRelay<[PreferenceStatus]>(value: [])
+
+    init(fetchEventsUseCase: FetchPreferenceEventsUseCase,
+         fetchStatusUseCase: FetchPreferenceStatusUseCase,
+         updateStatusUseCase: UpdatePreferenceStatusUseCase,
+         deleteEventUseCase: DeletePreferenceEventUseCase,
+         deleteStatusUseCase: DeletePreferenceStatusUseCase) {
+        self.fetchEventsUseCase = fetchEventsUseCase
+        self.fetchStatusUseCase = fetchStatusUseCase
+        self.updateStatusUseCase = updateStatusUseCase
+        self.deleteEventUseCase = deleteEventUseCase
+        self.deleteStatusUseCase = deleteStatusUseCase
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        layout()
+        bind()
+        load()
+    }
+
+    private func layout() {
+        view.backgroundColor = ThemeColor.background1
+        view.addSubview(tableView)
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
+        tableView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+    }
+
+    private func bind() {
+        Observable.combineLatest(statuses, events)
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] _, _ in
+                self?.tableView.reloadData()
+            })
+            .disposed(by: disposeBag)
+
+        tableView.rx.itemSelected
+            .subscribe(onNext: { [weak self] indexPath in
+                guard let self else { return }
+                self.tableView.deselectRow(at: indexPath, animated: true)
+                guard Section(rawValue: indexPath.section) == .status else { return }
+                let status = self.statuses.value[indexPath.row]
+                self.showEditAlert(status: status)
+            })
+            .disposed(by: disposeBag)
+    }
+
+    private func load() {
+        fetchStatusUseCase.execute()
+            .observe(on: MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] items in
+                self?.statuses.accept(items)
+            })
+            .disposed(by: disposeBag)
+
+        fetchEventsUseCase.execute()
+            .observe(on: MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] items in
+                self?.events.accept(items.sorted { $0.timestamp > $1.timestamp })
+            })
+            .disposed(by: disposeBag)
+    }
+
+    private func showEditAlert(status: PreferenceStatus) {
+        let alert = UIAlertController(title: "수정", message: nil, preferredStyle: .actionSheet)
+        let relations: [PreferenceRelation] = [.like, .dislike, .want, .avoid]
+        relations.forEach { relation in
+            alert.addAction(UIAlertAction(title: relation.rawValue, style: .default) { [weak self] _ in
+                guard var self else { return }
+                var updated = status
+                updated.currentRelation = relation
+                updated.updatedAt = Date().timeIntervalSince1970
+                self.updateStatusUseCase.execute(status: updated)
+                    .subscribe(onSuccess: { [weak self] in
+                        guard let self else { return }
+                        if let idx = self.statuses.value.firstIndex(where: { $0.key == updated.key }) {
+                            var new = self.statuses.value
+                            new[idx] = updated
+                            self.statuses.accept(new)
+                        }
+                    })
+                    .disposed(by: self.disposeBag)
+            })
+        }
+        alert.addAction(UIAlertAction(title: "취소", style: .cancel))
+        present(alert, animated: true)
+    }
+}
+
+extension PreferenceHistoryViewController: UITableViewDataSource, UITableViewDelegate {
+    func numberOfSections(in tableView: UITableView) -> Int { Section.allCases.count }
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        switch Section(rawValue: section) {
+        case .status: return statuses.value.count
+        case .history: return events.value.count
+        case .none: return 0
+        }
+    }
+
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        Section(rawValue: section)?.title
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
+        switch Section(rawValue: indexPath.section) {
+        case .status:
+            let item = statuses.value[indexPath.row]
+            cell.textLabel?.text = "\(item.key) - \(item.currentRelation.rawValue)"
+        case .history:
+            let ev = events.value[indexPath.row]
+            let date = Date(timeIntervalSince1970: ev.timestamp)
+            let df = DateFormatter()
+            df.dateStyle = .short
+            df.timeStyle = .short
+            cell.textLabel?.text = "\(ev.key) [\(ev.relation.rawValue)] - \(df.string(from: date))"
+        case .none:
+            break
+        }
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        switch Section(rawValue: indexPath.section) {
+        case .status:
+            let key = statuses.value[indexPath.row].key
+            let delete = UIContextualAction(style: .destructive, title: "삭제") { [weak self] _, _, completion in
+                guard let self else { completion(true); return }
+                self.deleteStatusUseCase.execute(key: key)
+                    .subscribe(onSuccess: { [weak self] in
+                        var items = self?.statuses.value ?? []
+                        items.removeAll { $0.key == key }
+                        self?.statuses.accept(items)
+                    })
+                    .disposed(by: self.disposeBag)
+                completion(true)
+            }
+            return UISwipeActionsConfiguration(actions: [delete])
+        case .history:
+            guard let id = events.value[indexPath.row].id else { return nil }
+            let delete = UIContextualAction(style: .destructive, title: "삭제") { [weak self] _, _, completion in
+                guard let self else { completion(true); return }
+                self.deleteEventUseCase.execute(eventID: id)
+                    .subscribe(onSuccess: { [weak self] in
+                        var items = self?.events.value ?? []
+                        items.removeAll { $0.id == id }
+                        self?.events.accept(items)
+                    })
+                    .disposed(by: self.disposeBag)
+                completion(true)
+            }
+            return UISwipeActionsConfiguration(actions: [delete])
+        case .none:
+            return nil
+        }
+    }
+}

--- a/chatGPTTests/UpdateUserPreferenceUseCaseTests.swift
+++ b/chatGPTTests/UpdateUserPreferenceUseCaseTests.swift
@@ -22,6 +22,7 @@ final class StubEventRepository: PreferenceEventRepository {
         return .just(())
     }
     func fetch(uid: String) -> Single<[PreferenceEvent]> { .just([]) }
+    func delete(uid: String, eventID: String) -> Single<Void> { .just(()) }
 }
 
 final class StubStatusRepository: PreferenceStatusRepository {
@@ -35,6 +36,7 @@ final class StubStatusRepository: PreferenceStatusRepository {
         }
         return .just(())
     }
+    func delete(uid: String, key: String) -> Single<Void> { .just(()) }
 }
 
 final class StubAuthRepository: AuthRepository {


### PR DESCRIPTION
## Summary
- support deleting preference items in Firestore
- show preference history and status
- inject preference use cases to coordinator, main/menu scenes

## Testing
- `swift test -l` *(fails: unable to clone RxSwift due to CONNECT tunnel 403)*

------
https://chatgpt.com/codex/tasks/task_e_6888e81c0888832bba2c27903b8f0bc1