### PR TITLE
Fix edit alert binding

### DIFF
--- a/chatGPT/Presentation/Scene/PreferenceHistoryViewController.swift
+++ b/chatGPT/Presentation/Scene/PreferenceHistoryViewController.swift
@@ -98,7 +98,7 @@ final class PreferenceHistoryViewController: UIViewController {
         let relations: [PreferenceRelation] = [.like, .dislike, .want, .avoid]
         relations.forEach { relation in
             alert.addAction(UIAlertAction(title: relation.rawValue, style: .default) { [weak self] _ in
-                guard var self else { return }
+                guard let self else { return }
                 var updated = status
                 updated.currentRelation = relation
                 updated.updatedAt = Date().timeIntervalSince1970


### PR DESCRIPTION
## Summary
- fix incorrect optional binding in `showEditAlert`

## Testing
- `swift test` *(fails: unable to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6889e9847be8832ba4a6067400b02514