### PR TITLE
Update preference usecase subscribe

### DIFF
--- a/chatGPT/Presentation/Scene/ChatViewModel.swift
+++ b/chatGPT/Presentation/Scene/ChatViewModel.swift
@@ -106,7 +106,8 @@ final class ChatViewModel {
         
         
         updatePreferenceUseCase.execute(prompt: prompt)
-            .subscribe()
+            .subscribe(onSuccess: { },
+                       onFailure: { print("preference error:", $0) })
             .disposed(by: disposeBag)
         
         let allData = attachments.compactMap { item -> Data? in


### PR DESCRIPTION
## Summary
- ignore errors from updating user preferences in ChatViewModel

## Testing
- `swift test -l` *(fails: unable to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6889e98dc78c832b8a34f83f03800262