### PR TITLE
feature/context-storage

### DIFF
--- a/chatGPT/Data/ChatContextRepositoryImpl.swift
+++ b/chatGPT/Data/ChatContextRepositoryImpl.swift
@@ -7,9 +7,24 @@
 
 import Foundation
 
+// MARK: 채팅 문맥 저장 구현체
+
 final class ChatContextRepositoryImpl: ChatContextRepository {
+    private let messagesKey = "chatContextMessages"
+    private let summaryKey = "chatContextSummary"
+    private let userDefaults: UserDefaults
+
     private var storedMessages: [Message] = []
     private(set) var summary: String?
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+        if let data = userDefaults.data(forKey: messagesKey),
+           let messages = try? JSONDecoder().decode([Message].self, from: data) {
+            self.storedMessages = messages
+        }
+        self.summary = userDefaults.string(forKey: summaryKey)
+    }
 
     var messages: [Message] {
         storedMessages
@@ -17,25 +32,40 @@ final class ChatContextRepositoryImpl: ChatContextRepository {
 
     func append(role: RoleType, content: String) {
         storedMessages.append(Message(role: role, content: content))
+        save()
     }
 
     func updateSummary(_ summary: String) {
         self.summary = summary
+        save()
     }
 
     func replace(messages: [Message], summary: String?) {
         self.storedMessages = messages
         self.summary = summary
+        save()
     }
 
     func trim(to maxCount: Int) {
         if storedMessages.count > maxCount {
             storedMessages = Array(storedMessages.suffix(maxCount))
+            save()
         }
     }
 
     func clear() {
         storedMessages.removeAll()
         summary = nil
+        save()
+    }
+
+    private func save() {
+        let data = try? JSONEncoder().encode(storedMessages)
+        userDefaults.set(data, forKey: messagesKey)
+        if let summary {
+            userDefaults.set(summary, forKey: summaryKey)
+        } else {
+            userDefaults.removeObject(forKey: summaryKey)
+        }
     }
 }

--- a/chatGPTTests/ChatContextRepositoryImplTests.swift
+++ b/chatGPTTests/ChatContextRepositoryImplTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+@testable import chatGPT
+
+final class ChatContextRepositoryImplTests: XCTestCase {
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "test_\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        super.tearDown()
+    }
+
+    func test_persist_messages_and_summary() {
+        var repo: ChatContextRepositoryImpl? = ChatContextRepositoryImpl(userDefaults: defaults)
+        repo?.append(role: .user, content: "hi")
+        repo?.updateSummary("sum")
+        repo = nil
+        let loaded = ChatContextRepositoryImpl(userDefaults: defaults)
+        XCTAssertEqual(loaded.messages.first?.content, "hi")
+        XCTAssertEqual(loaded.summary, "sum")
+    }
+}


### PR DESCRIPTION
## Summary
- persist chat context via `UserDefaults`
- load stored messages and summary on init
- add tests for persistence

## Testing
- `swift test` *(fails: unable to fetch RxSwift)*

------
https://chatgpt.com/codex/tasks/task_e_6889f0b67d08832b922a3282d8bc06ed