### PR TITLE
Add tests for preference weight decay

### DIFF
--- a/chatGPTTests/CalculatePreferenceUseCaseTests.swift
+++ b/chatGPTTests/CalculatePreferenceUseCaseTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+import RxSwift
+@testable import chatGPT
+
+final class StubEventRepository: PreferenceEventRepository {
+    var events: [PreferenceEvent] = []
+    func add(uid: String, events: [PreferenceEvent]) -> Single<Void> { .just(()) }
+    func fetch(uid: String) -> Single<[PreferenceEvent]> { .just(events) }
+    func delete(uid: String, eventID: String) -> Single<Void> { .just(()) }
+}
+
+final class StubAuthRepository: AuthRepository {
+    var user: AuthUser? = AuthUser(uid: "u1", displayName: nil, photoURL: nil)
+    func observeAuthState() -> Observable<AuthUser?> { .empty() }
+    func currentUser() -> AuthUser? { user }
+    func signOut() throws {}
+}
+
+final class CalculatePreferenceUseCaseTests: XCTestCase {
+    private var useCase: CalculatePreferenceUseCase!
+    private var repo: StubEventRepository!
+    private var disposeBag: DisposeBag!
+
+    override func setUp() {
+        super.setUp()
+        repo = StubEventRepository()
+        let authRepo = StubAuthRepository()
+        let getUser = GetCurrentUserUseCase(repository: authRepo)
+        useCase = CalculatePreferenceUseCase(eventRepository: repo,
+                                             getCurrentUserUseCase: getUser)
+        disposeBag = DisposeBag()
+    }
+
+    func test_returns_sorted_by_decay_weight() {
+        let now = Date().timeIntervalSince1970
+        repo.events = [
+            PreferenceEvent(key: "a", relation: .like, timestamp: now - 1000),
+            PreferenceEvent(key: "b", relation: .like, timestamp: now - 10),
+            PreferenceEvent(key: "a", relation: .like, timestamp: now - 20)
+        ]
+        let exp = expectation(description: "sorted")
+        var output: [PreferenceEvent] = []
+        useCase.execute(top: 2)
+            .subscribe(onSuccess: { events in
+                output = events
+                exp.fulfill()
+            })
+            .disposed(by: disposeBag)
+        waitForExpectations(timeout: 1)
+        XCTAssertEqual(output.count, 2)
+        XCTAssertEqual(output[0].key, "a")
+        XCTAssertEqual(output[1].key, "b")
+    }
+
+    func test_handles_large_time_difference() {
+        let now = Date().timeIntervalSince1970
+        repo.events = [
+            PreferenceEvent(key: "old", relation: .like, timestamp: now - 31_536_000),
+            PreferenceEvent(key: "recent", relation: .like, timestamp: now - 1)
+        ]
+        let exp = expectation(description: "decay")
+        var output: [PreferenceEvent] = []
+        useCase.execute(top: 2)
+            .subscribe(onSuccess: { events in
+                output = events
+                exp.fulfill()
+            })
+            .disposed(by: disposeBag)
+        waitForExpectations(timeout: 1)
+        XCTAssertEqual(output.first?.key, "recent")
+        XCTAssertEqual(output.last?.key, "old")
+    }
+}
+


### PR DESCRIPTION
## Summary
- add CalculatePreferenceUseCaseTests verifying decay-adjusted sorting

## Testing
- `swift test -l` *(fails: unable to fetch RxSwift)*

------
https://chatgpt.com/codex/tasks/task_e_6889f262ba68832bb2b88a48f6d4d3fd