### PR TITLE
Remove Korean parsing

### DIFF
--- a/chatGPT/Domain/UseCase/UpdateUserPreferenceUseCase.swift
+++ b/chatGPT/Domain/UseCase/UpdateUserPreferenceUseCase.swift
@@ -69,47 +69,27 @@ final class UpdateUserPreferenceUseCase {
         let tokens = MorphTokenizer.tokenize(prompt)
         var items: [PreferenceItem] = []
         var index = 0
-        func nextNoun(after idx: Int) -> (String, Int)? {
-            var i = idx + 1
-            while i < tokens.count {
-                if tokens[i].isNoun {
-                    return (tokens[i].text, i)
-                }
-                i += 1
-            }
-            return nil
+        func nextWord(after idx: Int) -> (String, Int)? {
+            let next = idx + 1
+            guard next < tokens.count else { return nil }
+            return (tokens[next].text, next)
         }
 
         while index < tokens.count {
             let token = tokens[index].text
             let time = Date().timeIntervalSince1970
-            if token == "like" || token.hasPrefix("좋아"), let (key, i) = nextNoun(after: index) {
+            if token == "like", let (key, i) = nextWord(after: index) {
                 items.append(PreferenceItem(key: key, relation: .like, updatedAt: time, count: 1))
                 index = i
-            } else if token == "dislike" || token.hasPrefix("싫어"), let (key, i) = nextNoun(after: index) {
+            } else if token == "dislike", let (key, i) = nextWord(after: index) {
                 items.append(PreferenceItem(key: key, relation: .dislike, updatedAt: time, count: 1))
                 index = i
-            } else if token == "want" || token.hasPrefix("원") || token.contains("싶"), let (key, i) = nextNoun(after: index) {
+            } else if token == "want", let (key, i) = nextWord(after: index) {
                 items.append(PreferenceItem(key: key, relation: .want, updatedAt: time, count: 1))
                 index = i
-            } else if token == "avoid" || token.hasPrefix("피하"), let (key, i) = nextNoun(after: index) {
+            } else if token == "avoid", let (key, i) = nextWord(after: index) {
                 items.append(PreferenceItem(key: key, relation: .avoid, updatedAt: time, count: 1))
                 index = i
-            } else if tokens[index].isNoun, index + 1 < tokens.count {
-                let next = tokens[index + 1].text
-                if next == "like" || next.hasPrefix("좋아") {
-                    items.append(PreferenceItem(key: token, relation: .like, updatedAt: time, count: 1))
-                    index += 1
-                } else if next == "dislike" || next.hasPrefix("싫어") {
-                    items.append(PreferenceItem(key: token, relation: .dislike, updatedAt: time, count: 1))
-                    index += 1
-                } else if next == "want" || next.hasPrefix("원") || next.contains("싶") {
-                    items.append(PreferenceItem(key: token, relation: .want, updatedAt: time, count: 1))
-                    index += 1
-                } else if next == "avoid" || next.hasPrefix("피하") {
-                    items.append(PreferenceItem(key: token, relation: .avoid, updatedAt: time, count: 1))
-                    index += 1
-                }
             }
             index += 1
         }

--- a/chatGPT/Domain/Utils/MorphTokenizer.swift
+++ b/chatGPT/Domain/Utils/MorphTokenizer.swift
@@ -6,44 +6,11 @@ struct MorphToken {
 }
 
 struct MorphTokenizer {
-    private static let postpositions: [String] = [
-        "은", "는", "이", "가", "을", "를", "에", "에서", "에게", "한테", "와", "과",
-        "랑", "으로", "로", "도", "만", "까지", "부터", "처럼", "뿐", "조차", "마저", "보다",
-        "께", "께서"
-    ]
-    private static let verbEndings: [String] = [
-        "다", "고", "하고", "해", "해요", "하는", "하다", "했다", "한다",
-        "싶어", "싶다", "싶어라", "하", "되", "됐다", "시", "어"
-    ]
-
     static func tokenize(_ text: String) -> [MorphToken] {
         let separators = CharacterSet.whitespacesAndNewlines.union(.punctuationCharacters)
-        var tokens: [MorphToken] = []
-        for raw in text.components(separatedBy: separators) where !raw.isEmpty {
-            var word = raw.trimmingCharacters(in: .punctuationCharacters)
-            var removed = true
-            while removed {
-                removed = false
-                for pos in postpositions {
-                    if word.hasSuffix(pos) {
-                        word = String(word.dropLast(pos.count))
-                        removed = true
-                    }
-                }
-            }
-            let lower = word.lowercased()
-            let isHangul = lower.unicodeScalars.allSatisfy { $0.value >= 0xAC00 && $0.value <= 0xD7A3 }
-            var isNoun = true
-            if isHangul {
-                for end in verbEndings {
-                    if lower.hasSuffix(end) {
-                        isNoun = false
-                        break
-                    }
-                }
-            }
-            tokens.append(MorphToken(text: lower, isNoun: isNoun))
-        }
-        return tokens
+        return text
+            .components(separatedBy: separators)
+            .filter { !$0.isEmpty }
+            .map { MorphToken(text: $0.lowercased(), isNoun: true) }
     }
 }

--- a/chatGPTTests/UpdateUserPreferenceUseCaseTests.swift
+++ b/chatGPTTests/UpdateUserPreferenceUseCaseTests.swift
@@ -84,11 +84,8 @@ final class UpdateUserPreferenceUseCaseTests: XCTestCase {
             .subscribe(onSuccess: { _ in exp.fulfill() })
             .disposed(by: disposeBag)
         waitForExpectations(timeout: 1)
-        let item = repo.updatedItems.first
-        XCTAssertEqual(item?.key, "사과")
-        XCTAssertEqual(item?.relation, .like)
-        XCTAssertEqual(item?.count, 1)
-        XCTAssertEqual(eventRepo.events.first?.key, "사과")
+        XCTAssertTrue(repo.updatedItems.isEmpty)
+        XCTAssertTrue(eventRepo.events.isEmpty)
     }
 
     func test_avoid_sentence() {
@@ -98,10 +95,7 @@ final class UpdateUserPreferenceUseCaseTests: XCTestCase {
             .subscribe(onSuccess: { _ in exp.fulfill() })
             .disposed(by: disposeBag)
         waitForExpectations(timeout: 1)
-        let item = repo.updatedItems.first
-        XCTAssertEqual(item?.key, "맥주")
-        XCTAssertEqual(item?.relation, .avoid)
-        XCTAssertEqual(item?.count, 1)
+        XCTAssertTrue(repo.updatedItems.isEmpty)
     }
 
     func test_want_sentence() {
@@ -111,10 +105,7 @@ final class UpdateUserPreferenceUseCaseTests: XCTestCase {
             .subscribe(onSuccess: { _ in exp.fulfill() })
             .disposed(by: disposeBag)
         waitForExpectations(timeout: 1)
-        let item = repo.updatedItems.first
-        XCTAssertEqual(item?.key, "콜라")
-        XCTAssertEqual(item?.relation, .want)
-        XCTAssertEqual(item?.count, 1)
+        XCTAssertTrue(repo.updatedItems.isEmpty)
     }
 
     func test_multiple_preferences_count() {
@@ -124,9 +115,7 @@ final class UpdateUserPreferenceUseCaseTests: XCTestCase {
             .subscribe(onSuccess: { _ in exp.fulfill() })
             .disposed(by: disposeBag)
         waitForExpectations(timeout: 1)
-        XCTAssertEqual(repo.updatedItems.count, 2)
-        XCTAssertEqual(repo.updatedItems.first?.count, 1)
-        XCTAssertEqual(repo.updatedItems.last?.count, 1)
+        XCTAssertTrue(repo.updatedItems.isEmpty)
     }
 
     func test_translation() {
@@ -149,11 +138,7 @@ final class UpdateUserPreferenceUseCaseTests: XCTestCase {
             .subscribe(onSuccess: { _ in exp.fulfill() })
             .disposed(by: disposeBag)
         waitForExpectations(timeout: 1)
-        XCTAssertEqual(repo.updatedItems.count, 2)
-        XCTAssertEqual(repo.updatedItems[0].relation, .like)
-        XCTAssertEqual(repo.updatedItems[0].key, "사과")
-        XCTAssertEqual(repo.updatedItems[1].relation, .dislike)
-        XCTAssertEqual(repo.updatedItems[1].key, "바나나")
+        XCTAssertTrue(repo.updatedItems.isEmpty)
     }
 
     func test_parse_korean_sentence() {
@@ -163,11 +148,7 @@ final class UpdateUserPreferenceUseCaseTests: XCTestCase {
             .subscribe(onSuccess: { _ in exp.fulfill() })
             .disposed(by: disposeBag)
         waitForExpectations(timeout: 1)
-        XCTAssertEqual(repo.updatedItems.count, 2)
-        XCTAssertEqual(repo.updatedItems[0].relation, .like)
-        XCTAssertEqual(repo.updatedItems[0].key, "사과")
-        XCTAssertEqual(repo.updatedItems[1].relation, .avoid)
-        XCTAssertEqual(repo.updatedItems[1].key, "맥주")
+        XCTAssertTrue(repo.updatedItems.isEmpty)
     }
 
     func test_parse_with_punctuation_and_case() {
@@ -177,10 +158,6 @@ final class UpdateUserPreferenceUseCaseTests: XCTestCase {
             .subscribe(onSuccess: { _ in exp.fulfill() })
             .disposed(by: disposeBag)
         waitForExpectations(timeout: 1)
-        XCTAssertEqual(repo.updatedItems.count, 2)
-        XCTAssertEqual(repo.updatedItems[0].key, "사과")
-        XCTAssertEqual(repo.updatedItems[0].relation, .like)
-        XCTAssertEqual(repo.updatedItems[1].key, "브로콜리")
-        XCTAssertEqual(repo.updatedItems[1].relation, .avoid)
+        XCTAssertTrue(repo.updatedItems.isEmpty)
     }
 }


### PR DESCRIPTION
## Summary
- simplify `MorphTokenizer` and drop Hangul-specific logic
- update `UpdateUserPreferenceUseCase` to parse only English keywords
- adjust tests for the new behavior

## Testing
- `swift test --parallel` *(fails: unable to fetch RxSwift)*

------
https://chatgpt.com/codex/tasks/task_e_688a0e71d874832b849ae34f3821cf65