### PR TITLE
update user profile

### DIFF
--- a/chatGPT.xcodeproj/project.pbxproj
+++ b/chatGPT.xcodeproj/project.pbxproj
@@ -14,7 +14,8 @@
 		2C81557F25F64DF8A4771CF5 /* FetchPreferenceEventsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D0B906B8B645D2BD138DD4 /* FetchPreferenceEventsUseCase.swift */; };
 		30beb33a115706b3629c8e71 /* FetchUserProfileUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30beb33a115706b3629c8e72 /* FetchUserProfileUseCase.swift */; };
 		348D57FA354A44F6B99CF055 /* FetchPreferenceStatusUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8A68DEFEA04987AB0B477C /* FetchPreferenceStatusUseCase.swift */; };
-		34d7c14c73e95b22aca8a791 /* UpdateUserProfileUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34d7c14c73e95b22aca8a792 /* UpdateUserProfileUseCase.swift */; };
+                34d7c14c73e95b22aca8a791 /* UpdateUserProfileUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34d7c14c73e95b22aca8a792 /* UpdateUserProfileUseCase.swift */; };
+                5CBFFE28922043738E627A35 /* UpdateUserProfileFromPromptUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CBFFE28922043738E627A36 /* UpdateUserProfileFromPromptUseCase.swift */; };
 		3777336EB7FFED779D382136 /* ChatComposerImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D72D81EC3779FD6C571F839 /* ChatComposerImageCell.swift */; };
 		4f89184b5697445da8d67bb5 /* SignOutUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 896db1fb7f9843dbb43a9831 /* SignOutUseCase.swift */; };
 		612B81605F45468EA3B3EDEE /* PreferenceHistoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66C4A0471F754726A0976FCD /* PreferenceHistoryViewController.swift */; };
@@ -178,7 +179,8 @@
 		06D64F3141B541D0BD80EE52 /* StreamToggleCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamToggleCell.swift; sourceTree = "<group>"; };
 		0C8A7A046A9642F6B9514D69 /* UpdatePreferenceStatusUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePreferenceStatusUseCase.swift; sourceTree = "<group>"; };
 		30beb33a115706b3629c8e72 /* FetchUserProfileUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchUserProfileUseCase.swift; sourceTree = "<group>"; };
-		34d7c14c73e95b22aca8a792 /* UpdateUserProfileUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateUserProfileUseCase.swift; sourceTree = "<group>"; };
+                34d7c14c73e95b22aca8a792 /* UpdateUserProfileUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateUserProfileUseCase.swift; sourceTree = "<group>"; };
+                5CBFFE28922043738E627A36 /* UpdateUserProfileFromPromptUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateUserProfileFromPromptUseCase.swift; sourceTree = "<group>"; };
 		3523b66a0b6a4beab384ad00 /* ChatContextRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatContextRepository.swift; sourceTree = "<group>"; };
 		3F8A68DEFEA04987AB0B477C /* FetchPreferenceStatusUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchPreferenceStatusUseCase.swift; sourceTree = "<group>"; };
 		3e924cb7e10d40a1a28fc225 /* ObserveConversationsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObserveConversationsUseCase.swift; sourceTree = "<group>"; };
@@ -565,9 +567,10 @@
 				9b8f82223d524f878b330338 /* ObserveAuthStateUseCase.swift */,
 				79766A3D81B253405488FCA1 /* AppendMessageUseCase.swift */,
 				F20000032F00000300000003 /* UploadFilesUseCase.swift */,
-				30beb33a115706b3629c8e72 /* FetchUserProfileUseCase.swift */,
-				34d7c14c73e95b22aca8a792 /* UpdateUserProfileUseCase.swift */,
-				3e924cb7e10d40a1a28fc225 /* ObserveConversationsUseCase.swift */,
+                                30beb33a115706b3629c8e72 /* FetchUserProfileUseCase.swift */,
+                                34d7c14c73e95b22aca8a792 /* UpdateUserProfileUseCase.swift */,
+                                5CBFFE28922043738E627A36 /* UpdateUserProfileFromPromptUseCase.swift */,
+                                3e924cb7e10d40a1a28fc225 /* ObserveConversationsUseCase.swift */,
 				D1429C4B96A13E73C35752E4 /* UpdateConversationTitleUseCase.swift */,
 				64EB7DD9103C65295FB89E7C /* DeleteConversationUseCase.swift */,
 				94D0B906B8B645D2BD138DD4 /* FetchPreferenceEventsUseCase.swift */,
@@ -910,9 +913,10 @@
 				6ec95adc9f08d9d82b7d1434 /* FirestoreUserProfileRepository.swift in Sources */,
 				dce5de4f3362a58526dad76a /* UserProfile.swift in Sources */,
 				6f19f0255b6cb1ec8b35dae5 /* UserProfileRepository.swift in Sources */,
-				30beb33a115706b3629c8e71 /* FetchUserProfileUseCase.swift in Sources */,
-				34d7c14c73e95b22aca8a791 /* UpdateUserProfileUseCase.swift in Sources */,
-				d4ae3188874b4ea4a0abdef2 /* ObserveAuthStateUseCase.swift in Sources */,
+                                30beb33a115706b3629c8e71 /* FetchUserProfileUseCase.swift in Sources */,
+                                34d7c14c73e95b22aca8a791 /* UpdateUserProfileUseCase.swift in Sources */,
+                                5CBFFE28922043738E627A35 /* UpdateUserProfileFromPromptUseCase.swift in Sources */,
+                                d4ae3188874b4ea4a0abdef2 /* ObserveAuthStateUseCase.swift in Sources */,
 				edab8d1cb29b4a0d8fc109d2 /* ObserveConversationsUseCase.swift in Sources */,
 				F166CA132DF9A39B00AAB5B0 /* AppDelegate.swift in Sources */,
 				F117E0752E0184A900D1C95F /* OpenAIRepository.swift in Sources */,

--- a/chatGPT/Data/FirestoreUserProfileRepository.swift
+++ b/chatGPT/Data/FirestoreUserProfileRepository.swift
@@ -18,7 +18,16 @@ final class FirestoreUserProfileRepository: UserProfileRepository {
                     if let str = data["photoURL"] as? String {
                         url = URL(string: str)
                     }
-                    single(.success(UserProfile(displayName: name, photoURL: url)))
+                    let age = data["age"] as? Int
+                    let gender = data["gender"] as? String
+                    let job = data["job"] as? String
+                    let interest = data["interest"] as? String
+                    single(.success(UserProfile(displayName: name,
+                                              photoURL: url,
+                                              age: age,
+                                              gender: gender,
+                                              job: job,
+                                              interest: interest)))
                 } else if let error = error {
                     single(.failure(error))
                 } else {
@@ -34,6 +43,10 @@ final class FirestoreUserProfileRepository: UserProfileRepository {
             var data: [String: Any] = [:]
             if let name = profile.displayName { data["displayName"] = name }
             if let url = profile.photoURL { data["photoURL"] = url.absoluteString }
+            if let age = profile.age { data["age"] = age }
+            if let gender = profile.gender { data["gender"] = gender }
+            if let job = profile.job { data["job"] = job }
+            if let interest = profile.interest { data["interest"] = interest }
             self.db.collection("profiles").document(uid).setData(data, merge: true) { error in
                 if let error = error {
                     single(.failure(error))

--- a/chatGPT/Domain/Entity/UserProfile.swift
+++ b/chatGPT/Domain/Entity/UserProfile.swift
@@ -3,4 +3,8 @@ import Foundation
 struct UserProfile: Codable, Equatable {
     var displayName: String?
     var photoURL: URL?
+    var age: Int?
+    var gender: String?
+    var job: String?
+    var interest: String?
 }

--- a/chatGPT/Domain/UseCase/SendChatWithContextUseCase.swift
+++ b/chatGPT/Domain/UseCase/SendChatWithContextUseCase.swift
@@ -31,12 +31,16 @@ final class SendChatWithContextUseCase {
                  model: OpenAIModel,
                  stream: Bool,
                  preference: String?,
+                 profile: String?,
                  images: [Data] = [],
                  files: [Data] = [],
                  completion: @escaping (Result<String, Error>) -> Void) {
         var messages = [Message]()
         if let preference {
             messages.append(Message(role: .system, content: preference))
+        }
+        if let profile {
+            messages.append(Message(role: .system, content: profile))
         }
         if let summary = contextRepository.summary {
             messages.append(Message(role: .system, content: summary))
@@ -92,11 +96,15 @@ final class SendChatWithContextUseCase {
     func stream(prompt: String,
                 model: OpenAIModel,
                 preference: String?,
+                profile: String?,
                 images: [Data] = [],
                 files: [Data] = []) -> Observable<String> {
         var messages = [Message]()
         if let preference {
             messages.append(Message(role: .system, content: preference))
+        }
+        if let profile {
+            messages.append(Message(role: .system, content: profile))
         }
         if let summary = contextRepository.summary {
             messages.append(Message(role: .system, content: summary))

--- a/chatGPT/Domain/UseCase/UpdateUserProfileFromPromptUseCase.swift
+++ b/chatGPT/Domain/UseCase/UpdateUserProfileFromPromptUseCase.swift
@@ -1,0 +1,62 @@
+import Foundation
+import RxSwift
+
+final class UpdateUserProfileFromPromptUseCase {
+    private let fetchUseCase: FetchUserProfileUseCase
+    private let updateUseCase: UpdateUserProfileUseCase
+    private let translationRepository: TranslationRepository
+
+    init(fetchUseCase: FetchUserProfileUseCase,
+         updateUseCase: UpdateUserProfileUseCase,
+         translationRepository: TranslationRepository) {
+        self.fetchUseCase = fetchUseCase
+        self.updateUseCase = updateUseCase
+        self.translationRepository = translationRepository
+    }
+
+    func execute(prompt: String) -> Single<UserProfile> {
+        fetchUseCase.execute()
+            .catchAndReturn(nil)
+            .flatMap { [weak self] current -> Single<UserProfile> in
+                guard let self else { return .just(current ?? UserProfile()) }
+                return self.translationRepository.translateToEnglish(prompt)
+                    .map { [weak self] in
+                        self?.parse(text: $0, base: current ?? UserProfile()) ?? UserProfile()
+                    }
+            }
+            .flatMap { [weak self] profile in
+                guard let self else { return .just(profile) }
+                return self.updateUseCase.execute(profile: profile).map { profile }
+            }
+    }
+
+    private func parse(text: String, base: UserProfile) -> UserProfile {
+        var profile = base
+        let lower = text.lowercased()
+        if let age = self.match(text: lower, pattern: "i am (\\d{1,3}) years old"), let num = Int(age) {
+            profile.age = num
+        }
+        if lower.contains("i am male") || lower.contains("i'm male") {
+            profile.gender = "male"
+        } else if lower.contains("i am female") || lower.contains("i'm female") {
+            profile.gender = "female"
+        }
+        if let job = self.match(text: lower, pattern: "my job is ([a-z ]+)") {
+            profile.job = job.trimmingCharacters(in: .whitespaces)
+        } else if let job = self.match(text: lower, pattern: "i work as ([a-z ]+)") {
+            profile.job = job.trimmingCharacters(in: .whitespaces)
+        }
+        if let interest = self.match(text: lower, pattern: "i am interested in ([a-z ]+)") {
+            profile.interest = interest.trimmingCharacters(in: .whitespaces)
+        }
+        return profile
+    }
+
+    private func match(text: String, pattern: String) -> String? {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        guard let match = regex.firstMatch(in: text, range: range), match.numberOfRanges > 1,
+              let range = Range(match.range(at: 1), in: text) else { return nil }
+        return String(text[range])
+    }
+}

--- a/chatGPT/Presentation/Coordinator/AppCoordinator.swift
+++ b/chatGPT/Presentation/Coordinator/AppCoordinator.swift
@@ -74,6 +74,11 @@ final class AppCoordinator {
             repository: profileRepository,
             getCurrentUserUseCase: getCurrentUserUseCase
         )
+        let updateProfileFromPromptUseCase = UpdateUserProfileFromPromptUseCase(
+            fetchUseCase: fetchProfileUseCase,
+            updateUseCase: updateProfileUseCase,
+            translationRepository: translationRepository
+        )
         let calculatePreferenceUseCase = CalculatePreferenceUseCase(
             eventRepository: eventRepository,
             getCurrentUserUseCase: getCurrentUserUseCase
@@ -166,6 +171,7 @@ final class AppCoordinator {
             parseMarkdownUseCase: parseMarkdownUseCase,
             calculatePreferenceUseCase: calculatePreferenceUseCase,
             updatePreferenceUseCase: updatePreferenceUseCase,
+            updateProfileFromPromptUseCase: updateProfileFromPromptUseCase,
             fetchProfileUseCase: fetchProfileUseCase,
             updateProfileUseCase: updateProfileUseCase,
             uploadFilesUseCase: uploadFilesUseCase,

--- a/chatGPT/Presentation/Scene/MainViewController.swift
+++ b/chatGPT/Presentation/Scene/MainViewController.swift
@@ -30,6 +30,7 @@ final class MainViewController: UIViewController {
     private let updatePreferenceUseCase: UpdateUserPreferenceUseCase
     private let fetchProfileUseCase: FetchUserProfileUseCase
     private let updateProfileUseCase: UpdateUserProfileUseCase
+    private let updateProfileFromPromptUseCase: UpdateUserProfileFromPromptUseCase
     private let fetchConversationMessagesUseCase: FetchConversationMessagesUseCase
     private let fetchPreferenceEventsUseCase: FetchPreferenceEventsUseCase
     private let fetchPreferenceStatusUseCase: FetchPreferenceStatusUseCase
@@ -166,6 +167,7 @@ final class MainViewController: UIViewController {
       parseMarkdownUseCase: ParseMarkdownUseCase,
       calculatePreferenceUseCase: CalculatePreferenceUseCase,
       updatePreferenceUseCase: UpdateUserPreferenceUseCase,
+      updateProfileFromPromptUseCase: UpdateUserProfileFromPromptUseCase,
       fetchProfileUseCase: FetchUserProfileUseCase,
       updateProfileUseCase: UpdateUserProfileUseCase,
       uploadFilesUseCase: UploadFilesUseCase,
@@ -185,6 +187,8 @@ final class MainViewController: UIViewController {
                                            contextRepository: contextRepository,
                                            calculatePreferenceUseCase: calculatePreferenceUseCase,
                                            updatePreferenceUseCase: updatePreferenceUseCase,
+                                           updateProfileFromPromptUseCase: updateProfileFromPromptUseCase,
+                                           fetchProfileUseCase: fetchProfileUseCase,
                                            uploadFilesUseCase: uploadFilesUseCase,
                                            generateImageUseCase: generateImageUseCase,
                                            detectImageRequestUseCase: detectImageRequestUseCase)
@@ -198,6 +202,7 @@ final class MainViewController: UIViewController {
         self.parseMarkdownUseCase = parseMarkdownUseCase
         self.calculatePreferenceUseCase = calculatePreferenceUseCase
         self.updatePreferenceUseCase = updatePreferenceUseCase
+        self.updateProfileFromPromptUseCase = updateProfileFromPromptUseCase
         self.fetchProfileUseCase = fetchProfileUseCase
         self.updateProfileUseCase = updateProfileUseCase
         self.fetchPreferenceEventsUseCase = fetchPreferenceEventsUseCase

--- a/chatGPTTests/ChatViewModelPreferenceTextTests.swift
+++ b/chatGPTTests/ChatViewModelPreferenceTextTests.swift
@@ -4,8 +4,8 @@ import RxSwift
 
 // Stub types implementing required protocols
 final class StubSendChatWithContextUseCase {
-    func execute(prompt: String, model: OpenAIModel, stream: Bool, preference: String?, images: [Data], files: [Data], completion: @escaping (Result<String, Error>) -> Void) {}
-    func stream(prompt: String, model: OpenAIModel, preference: String?, images: [Data], files: [Data]) -> Observable<String> { .empty() }
+    func execute(prompt: String, model: OpenAIModel, stream: Bool, preference: String?, profile: String?, images: [Data], files: [Data], completion: @escaping (Result<String, Error>) -> Void) {}
+    func stream(prompt: String, model: OpenAIModel, preference: String?, profile: String?, images: [Data], files: [Data]) -> Observable<String> { .empty() }
     func finalize(prompt: String, reply: String, model: OpenAIModel) {}
 }
 
@@ -29,6 +29,12 @@ final class StubGenerateImageUseCase {}
 final class StubDetectImageRequestUseCase {
     func execute(prompt: String) -> Single<Bool> { .just(false) }
 }
+final class StubUpdateUserProfileFromPromptUseCase {
+    func execute(prompt: String) -> Single<UserProfile> { .just(UserProfile()) }
+}
+final class StubFetchUserProfileUseCase {
+    func execute() -> Single<UserProfile?> { .just(nil) }
+}
 
 final class ChatViewModelPreferenceTextTests: XCTestCase {
     func test_preferenceText_sorts_and_truncates() {
@@ -41,6 +47,8 @@ final class ChatViewModelPreferenceTextTests: XCTestCase {
             contextRepository: StubChatContextRepository(),
             calculatePreferenceUseCase: StubCalculatePreferenceUseCase(),
             updatePreferenceUseCase: StubUpdateUserPreferenceUseCase(),
+            updateProfileFromPromptUseCase: StubUpdateUserProfileFromPromptUseCase(),
+            fetchProfileUseCase: StubFetchUserProfileUseCase(),
             uploadFilesUseCase: StubUploadFilesUseCase(),
             generateImageUseCase: StubGenerateImageUseCase(),
             detectImageRequestUseCase: StubDetectImageRequestUseCase()
@@ -54,5 +62,30 @@ final class ChatViewModelPreferenceTextTests: XCTestCase {
         ]
         let text = vm.preferenceText(from: events)
         XCTAssertEqual(text, "like: cake, avoid: apple, want: orange")
+    }
+
+    func test_profileText_builds_string() {
+        let vm = ChatViewModel(
+            sendMessageUseCase: StubSendChatWithContextUseCase(),
+            summarizeUseCase: StubSummarizeMessagesUseCase(),
+            saveConversationUseCase: StubSaveConversationUseCase(),
+            appendMessageUseCase: StubAppendMessageUseCase(),
+            fetchMessagesUseCase: StubFetchConversationMessagesUseCase(),
+            contextRepository: StubChatContextRepository(),
+            calculatePreferenceUseCase: StubCalculatePreferenceUseCase(),
+            updatePreferenceUseCase: StubUpdateUserPreferenceUseCase(),
+            updateProfileFromPromptUseCase: StubUpdateUserProfileFromPromptUseCase(),
+            fetchProfileUseCase: StubFetchUserProfileUseCase(),
+            uploadFilesUseCase: StubUploadFilesUseCase(),
+            generateImageUseCase: StubGenerateImageUseCase(),
+            detectImageRequestUseCase: StubDetectImageRequestUseCase()
+        )
+        var profile = UserProfile()
+        profile.age = 20
+        profile.gender = "male"
+        profile.job = "student"
+        profile.interest = "game"
+        let text = vm.profileText(from: profile)
+        XCTAssertEqual(text, "age: 20, gender: male, job: student, interest: game")
     }
 }


### PR DESCRIPTION
## Summary
- extend `UserProfile` with age, gender, job and interest
- persist new profile fields in Firestore
- create `UpdateUserProfileFromPromptUseCase` to parse profile info
- include profile context when chatting
- adjust `ChatViewModel` and scenes for profile handling
- update tests for new initializer

## Testing
- `swift test` *(fails: unable to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688b22a2e590832b9d0ac2aeeeab9229