### PR TITLE
feature/update-preference

### DIFF
--- a/chatGPT/Presentation/Coordinator/AppCoordinator.swift
+++ b/chatGPT/Presentation/Coordinator/AppCoordinator.swift
@@ -84,6 +84,10 @@ final class AppCoordinator {
             profileRepository: profileRepository,
             getCurrentUserUseCase: getCurrentUserUseCase
         )
+        let fetchPreferenceUseCase = FetchUserPreferenceUseCase(
+            repository: preferenceRepository,
+            getCurrentUserUseCase: getCurrentUserUseCase
+        )
         let fetchPreferenceEventsUseCase = FetchPreferenceEventsUseCase(
             repository: eventRepository,
             getCurrentUserUseCase: getCurrentUserUseCase
@@ -165,6 +169,7 @@ final class AppCoordinator {
             parseMarkdownUseCase: parseMarkdownUseCase,
             calculatePreferenceUseCase: calculatePreferenceUseCase,
             updatePreferenceUseCase: updatePreferenceUseCase,
+            fetchPreferenceUseCase: fetchPreferenceUseCase,
             fetchProfileUseCase: fetchProfileUseCase,
             updateProfileUseCase: updateProfileUseCase,
             uploadFilesUseCase: uploadFilesUseCase,

--- a/chatGPT/Presentation/Scene/MainViewController.swift
+++ b/chatGPT/Presentation/Scene/MainViewController.swift
@@ -28,6 +28,7 @@ final class MainViewController: UIViewController {
     private let parseMarkdownUseCase: ParseMarkdownUseCase
     private let calculatePreferenceUseCase: CalculatePreferenceUseCase
     private let updatePreferenceUseCase: AnalyzeUserInputUseCase
+    private let fetchPreferenceUseCase: FetchUserPreferenceUseCase
     private let fetchProfileUseCase: FetchUserProfileUseCase
     private let updateProfileUseCase: UpdateUserProfileUseCase
     private let fetchConversationMessagesUseCase: FetchConversationMessagesUseCase
@@ -166,6 +167,7 @@ final class MainViewController: UIViewController {
       parseMarkdownUseCase: ParseMarkdownUseCase,
       calculatePreferenceUseCase: CalculatePreferenceUseCase,
       updatePreferenceUseCase: AnalyzeUserInputUseCase,
+      fetchPreferenceUseCase: FetchUserPreferenceUseCase,
       fetchProfileUseCase: FetchUserProfileUseCase,
       updateProfileUseCase: UpdateUserProfileUseCase,
       uploadFilesUseCase: UploadFilesUseCase,
@@ -185,6 +187,7 @@ final class MainViewController: UIViewController {
                                            contextRepository: contextRepository,
                                            calculatePreferenceUseCase: calculatePreferenceUseCase,
                                            updatePreferenceUseCase: updatePreferenceUseCase,
+                                           fetchPreferenceUseCase: fetchPreferenceUseCase,
                                            fetchProfileUseCase: fetchProfileUseCase,
                                            uploadFilesUseCase: uploadFilesUseCase,
                                            generateImageUseCase: generateImageUseCase,
@@ -199,6 +202,7 @@ final class MainViewController: UIViewController {
         self.parseMarkdownUseCase = parseMarkdownUseCase
         self.calculatePreferenceUseCase = calculatePreferenceUseCase
         self.updatePreferenceUseCase = updatePreferenceUseCase
+        self.fetchPreferenceUseCase = fetchPreferenceUseCase
         self.fetchProfileUseCase = fetchProfileUseCase
         self.updateProfileUseCase = updateProfileUseCase
         self.fetchPreferenceEventsUseCase = fetchPreferenceEventsUseCase

--- a/chatGPTTests/ChatViewModelPreferenceTextTests.swift
+++ b/chatGPTTests/ChatViewModelPreferenceTextTests.swift
@@ -29,11 +29,21 @@ final class StubGenerateImageUseCase {}
 final class StubDetectImageRequestUseCase {
     func execute(prompt: String) -> Single<Bool> { .just(false) }
 }
-final class StubUpdateUserProfileFromPromptUseCase {
-    func execute(prompt: String) -> Single<UserProfile> { .just(UserProfile()) }
-}
 final class StubFetchUserProfileUseCase {
     func execute() -> Single<UserProfile?> { .just(nil) }
+}
+final class StubFetchUserPreferenceUseCase {
+    func execute() -> Single<UserPreference?> { .just(nil) }
+}
+final class StubUserPreferenceRepository: UserPreferenceRepository {
+    func fetch(uid: String) -> Single<UserPreference?> { .just(nil) }
+    func update(uid: String, items: [PreferenceItem]) -> Single<Void> { .just(()) }
+}
+final class StubAuthRepository: AuthRepository {
+    var user: AuthUser? = AuthUser(uid: "u1", displayName: nil, photoURL: nil)
+    func observeAuthState() -> Observable<AuthUser?> { .empty() }
+    func currentUser() -> AuthUser? { user }
+    func signOut() throws {}
 }
 
 final class ChatViewModelPreferenceTextTests: XCTestCase {
@@ -47,7 +57,7 @@ final class ChatViewModelPreferenceTextTests: XCTestCase {
             contextRepository: StubChatContextRepository(),
             calculatePreferenceUseCase: StubCalculatePreferenceUseCase(),
             updatePreferenceUseCase: StubAnalyzeUserInputUseCase(),
-            updateProfileFromPromptUseCase: StubUpdateUserProfileFromPromptUseCase(),
+            fetchPreferenceUseCase: StubFetchUserPreferenceUseCase(),
             fetchProfileUseCase: StubFetchUserProfileUseCase(),
             uploadFilesUseCase: StubUploadFilesUseCase(),
             generateImageUseCase: StubGenerateImageUseCase(),
@@ -74,7 +84,7 @@ final class ChatViewModelPreferenceTextTests: XCTestCase {
             contextRepository: StubChatContextRepository(),
             calculatePreferenceUseCase: StubCalculatePreferenceUseCase(),
             updatePreferenceUseCase: StubAnalyzeUserInputUseCase(),
-            updateProfileFromPromptUseCase: StubUpdateUserProfileFromPromptUseCase(),
+            fetchPreferenceUseCase: StubFetchUserPreferenceUseCase(),
             fetchProfileUseCase: StubFetchUserProfileUseCase(),
             uploadFilesUseCase: StubUploadFilesUseCase(),
             generateImageUseCase: StubGenerateImageUseCase(),


### PR DESCRIPTION
## Summary
- fetch stored preferences when ChatViewModel initializes
- use stored preferences if no recent events exist
- propagate new dependency through MainViewController and AppCoordinator
- adjust tests for new initializer

## Testing
- `swift test` *(fails: unable to fetch RxSwift due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_688b60a4e0b4832b8dd1d7e4f2ae77a4