### PR TITLE
Update UserProfile to dictionary

### DIFF
--- a/chatGPT/Domain/Entity/UserProfile.swift
+++ b/chatGPT/Domain/Entity/UserProfile.swift
@@ -1,10 +1,38 @@
 import Foundation
 
 struct UserProfile: Codable, Equatable {
-    var displayName: String?
-    var photoURL: URL?
-    var age: Int?
-    var gender: String?
-    var job: String?
-    var interest: String?
+    var attributes: [String: String] = [:]
+
+    init(attributes: [String: String] = [:]) {
+        self.attributes = attributes
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: DynamicKey.self)
+        var attrs: [String: String] = [:]
+        for key in container.allKeys {
+            if let value = try? container.decode(String.self, forKey: key) {
+                attrs[key.stringValue] = value
+            } else if let intValue = try? container.decode(Int.self, forKey: key) {
+                attrs[key.stringValue] = "\(intValue)"
+            } else if let doubleValue = try? container.decode(Double.self, forKey: key) {
+                attrs[key.stringValue] = "\(doubleValue)"
+            }
+        }
+        self.attributes = attrs
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: DynamicKey.self)
+        for (key, value) in attributes {
+            try container.encode(value, forKey: DynamicKey(stringValue: key)!)
+        }
+    }
+
+    struct DynamicKey: CodingKey {
+        var stringValue: String
+        init?(stringValue: String) { self.stringValue = stringValue }
+        var intValue: Int?
+        init?(intValue: Int) { return nil }
+    }
 }

--- a/chatGPT/Presentation/Scene/ChatViewModel.swift
+++ b/chatGPT/Presentation/Scene/ChatViewModel.swift
@@ -287,11 +287,9 @@ final class ChatViewModel {
     }
 
     func profileText(from profile: UserProfile) -> String? {
-        var parts: [String] = []
-        if let age = profile.age { parts.append("age: \(age)") }
-        if let gender = profile.gender { parts.append("gender: \(gender)") }
-        if let job = profile.job { parts.append("job: \(job)") }
-        if let interest = profile.interest { parts.append("interest: \(interest)") }
+        let parts = profile.attributes
+            .sorted { $0.key < $1.key }
+            .map { "\($0.key): \($0.value)" }
         return parts.isEmpty ? nil : parts.joined(separator: ", ")
     }
     

--- a/chatGPTTests/AnalyzeUserInputUseCaseTests.swift
+++ b/chatGPTTests/AnalyzeUserInputUseCaseTests.swift
@@ -63,7 +63,7 @@ final class AnalyzeUserInputUseCaseTests: XCTestCase {
     func test_updates_preference_and_profile() {
         openAI.analysisResult = PreferenceAnalysisResult(
             preferences: [PreferenceAnalysisResult.Preference(key: "coffee", relation: PreferenceRelation(rawValue: "like"))],
-            profile: UserProfile(age: 20, gender: "male", job: nil, interest: nil)
+            profile: UserProfile(attributes: ["age": "20", "gender": "male"])
         )
         let exp = expectation(description: "update")
         useCase.execute(prompt: "I like coffee")
@@ -72,6 +72,6 @@ final class AnalyzeUserInputUseCaseTests: XCTestCase {
         waitForExpectations(timeout: 1)
         XCTAssertEqual(prefRepo.updatedItems.first?.key, "coffee")
         XCTAssertEqual(prefRepo.updatedItems.first?.relation, PreferenceRelation(rawValue: "like"))
-        XCTAssertEqual(profileRepo.updated?.age, 20)
+        XCTAssertEqual(profileRepo.updated?.attributes["age"], "20")
     }
 }

--- a/chatGPTTests/ChatViewModelPreferenceTextTests.swift
+++ b/chatGPTTests/ChatViewModelPreferenceTextTests.swift
@@ -90,12 +90,13 @@ final class ChatViewModelPreferenceTextTests: XCTestCase {
             generateImageUseCase: StubGenerateImageUseCase(),
             detectImageRequestUseCase: StubDetectImageRequestUseCase()
         )
-        var profile = UserProfile()
-        profile.age = 20
-        profile.gender = "male"
-        profile.job = "student"
-        profile.interest = "game"
+        let profile = UserProfile(attributes: [
+            "age": "20",
+            "gender": "male",
+            "job": "student",
+            "interest": "game"
+        ])
         let text = vm.profileText(from: profile)
-        XCTAssertEqual(text, "age: 20, gender: male, job: student, interest: game")
+        XCTAssertEqual(text, "age: 20, gender: male, interest: game, job: student")
     }
 }


### PR DESCRIPTION
## Summary
- make UserProfile hold a flexible attributes dictionary
- loop through attributes when reading/writing Firestore
- adjust ChatViewModel to build profile text from attributes
- update tests for the new profile structure

## Testing
- `swift test` *(fails: unable to fetch RxSwift due to network)*

------
https://chatgpt.com/codex/tasks/task_e_688c93bda564832ba7ec94e1dfbdab21