### PR TITLE
update input analysis

### DIFF
--- a/chatGPT/Data/OpenAIRepositoryImpl.swift
+++ b/chatGPT/Data/OpenAIRepositoryImpl.swift
@@ -90,11 +90,15 @@ final class OpenAIRepositoryImpl: OpenAIRepository {
                 case .success(let decoded):
                     print(decoded)
                     let text = decoded.choices.first?.message.content ?? "{}"
-                    if let data = text.data(using: .utf8),
-                       let res = try? JSONDecoder().decode(PreferenceAnalysisResult.self, from: data) {
-                        single(.success(res))
+                    if let data = text.data(using: .utf8) {
+                        do {
+                            let res = try JSONDecoder().decode(PreferenceAnalysisResult.self, from: data)
+                            single(.success(res))
+                        } catch {
+                            single(.failure(OpenAIError.decodingError))
+                        }
                     } else {
-                        single(.success(PreferenceAnalysisResult(preferences: [], profile: nil)))
+                        single(.failure(OpenAIError.decodingError))
                     }
                 case .failure(let error):
                     single(.failure(error))

--- a/chatGPT/Domain/UseCase/AnalyzeUserInputUseCase.swift
+++ b/chatGPT/Domain/UseCase/AnalyzeUserInputUseCase.swift
@@ -17,6 +17,17 @@ final class AnalyzeUserInputUseCase {
         self.getCurrentUserUseCase = getCurrentUserUseCase
     }
 
+    private enum Strings {
+        static let parseError = NSLocalizedString(
+            "analyze_input_parse_error",
+            comment: "Failed to parse analysis result"
+        )
+        static let emptyResult = NSLocalizedString(
+            "analyze_input_empty",
+            comment: "No preferences detected"
+        )
+    }
+
     func execute(prompt: String) -> Single<Void> {
         guard let user = getCurrentUserUseCase.execute() else {
             return .error(PreferenceError.noUser)
@@ -24,7 +35,7 @@ final class AnalyzeUserInputUseCase {
         return openAIRepository.analyzeUserInput(prompt: prompt)
             .do(onSuccess: { result in
                 if result.preferences.isEmpty && result.profile == nil {
-                    print("Analyzed the user message, but no preferences or personal information detected.")
+                    print(Strings.emptyResult)
                 } else {
                     if !result.preferences.isEmpty {
                         let prefs = result.preferences
@@ -36,7 +47,17 @@ final class AnalyzeUserInputUseCase {
                         print("Profile ->", profile)
                     }
                 }
+            }, onError: { error in
+                if (error as? OpenAIError) == .decodingError {
+                    print(Strings.parseError)
+                }
             })
+            .catch { error in
+                if case OpenAIError.decodingError = error {
+                    return .just(PreferenceAnalysisResult(preferences: [], profile: nil))
+                }
+                return .error(error)
+            }
             .flatMap { [weak self] result -> Single<Void> in
                 guard let self else { return .just(()) }
                 let now = Date().timeIntervalSince1970

--- a/chatGPT/Resource/Base.lproj/Localizable.strings
+++ b/chatGPT/Resource/Base.lproj/Localizable.strings
@@ -1,0 +1,2 @@
+"analyze_input_parse_error" = "Failed to parse analysis result";
+"analyze_input_empty" = "Analyzed the user message, but no preferences or personal information detected.";


### PR DESCRIPTION
## Summary
- add error handling when decoding preference analysis result
- differentiate empty data vs parsing failure in `AnalyzeUserInputUseCase`
- store related localized strings

## Testing
- `swift test -l` *(fails: unable to fetch RxSwift)*

------
https://chatgpt.com/codex/tasks/task_e_688c96bfb380832baf18e58a91515d06