### PR TITLE
Handle non-string info values

### DIFF
--- a/chatGPT/Domain/Entity/PreferenceAnalysisResult.swift
+++ b/chatGPT/Domain/Entity/PreferenceAnalysisResult.swift
@@ -11,9 +11,66 @@ struct PreferenceAnalysisResult: Codable {
         self.info = info
     }
 
+    enum JSONValue: Codable {
+        case string(String)
+        case number(Double)
+        case bool(Bool)
+        case array([JSONValue])
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            if let str = try? container.decode(String.self) {
+                self = .string(str)
+                return
+            }
+            if let num = try? container.decode(Double.self) {
+                self = .number(num)
+                return
+            }
+            if let bool = try? container.decode(Bool.self) {
+                self = .bool(bool)
+                return
+            }
+            if let arr = try? container.decode([JSONValue].self) {
+                self = .array(arr)
+                return
+            }
+            self = .string("")
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            switch self {
+            case .string(let str):
+                try container.encode(str)
+            case .number(let num):
+                try container.encode(num)
+            case .bool(let bool):
+                try container.encode(bool)
+            case .array(let arr):
+                try container.encode(arr)
+            }
+        }
+
+        var stringValue: String {
+            switch self {
+            case .string(let str):
+                return str
+            case .number(let num):
+                let intVal = Int(num)
+                return Double(intVal) == num ? String(intVal) : String(num)
+            case .bool(let bool):
+                return bool ? "true" : "false"
+            case .array(let arr):
+                return arr.map { $0.stringValue }.joined(separator: ",")
+            }
+        }
+    }
+
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let attributes = try container.decode([String: String].self, forKey: .info)
+        let values = try container.decode([String: JSONValue].self, forKey: .info)
+        let attributes = values.mapValues { $0.stringValue }
         self.info = UserInfo(attributes: attributes)
     }
 

--- a/chatGPTTests/PreferenceAnalysisResultTests.swift
+++ b/chatGPTTests/PreferenceAnalysisResultTests.swift
@@ -8,4 +8,18 @@ final class PreferenceAnalysisResultTests: XCTestCase {
         let result = try JSONDecoder().decode(PreferenceAnalysisResult.self, from: data)
         XCTAssertEqual(result.info.attributes["occupation"], "iOS developer")
     }
+
+    func test_decoding_array_value() throws {
+        let json = #"{"info":{"hobby":["soccer","movie"]}}"#
+        let data = Data(json.utf8)
+        let result = try JSONDecoder().decode(PreferenceAnalysisResult.self, from: data)
+        XCTAssertEqual(result.info.attributes["hobby"], "soccer,movie")
+    }
+
+    func test_decoding_number_value() throws {
+        let json = #"{"info":{"age":25}}"#
+        let data = Data(json.utf8)
+        let result = try JSONDecoder().decode(PreferenceAnalysisResult.self, from: data)
+        XCTAssertEqual(result.info.attributes["age"], "25")
+    }
 }


### PR DESCRIPTION
## Summary
- decode various value types in `PreferenceAnalysisResult`
- map arrays and numbers to string form when saving user info
- test array and number decoding

## Testing
- `swift test -q` *(fails: unable to fetch RxSwift)*

------
https://chatgpt.com/codex/tasks/task_e_688cb25dc228832bbe1e7c9f360f564b