### PR TITLE
codex/store-user-facts

### DIFF
--- a/chatGPT/Data/FirestoreUserInfoRepository.swift
+++ b/chatGPT/Data/FirestoreUserInfoRepository.swift
@@ -11,40 +11,60 @@ final class FirestoreUserInfoRepository: UserInfoRepository {
 
     func fetch(uid: String) -> Single<UserInfo?> {
         Single.create { single in
-            self.db.collection("userInfo").document(uid).getDocument { snapshot, error in
-                if let data = snapshot?.data() {
-                    var attributes: [String: String] = [:]
-                    data.forEach { key, value in
-                        if let str = value as? String {
-                            attributes[key] = str
-                        } else {
-                            attributes[key] = "\(value)"
+            self.db.collection("profiles")
+                .document(uid)
+                .collection("facts")
+                .getDocuments { snapshot, error in
+                    if let docs = snapshot?.documents {
+                        var result: [String: [UserFact]] = [:]
+                        for doc in docs {
+                            let data = doc.data()
+                            guard
+                                let name = data["name"] as? String,
+                                let value = data["value"] as? String,
+                                let count = data["count"] as? Int,
+                                let first = data["firstMentioned"] as? TimeInterval,
+                                let last = data["lastMentioned"] as? TimeInterval
+                            else { continue }
+                            let fact = UserFact(value: value, count: count, firstMentioned: first, lastMentioned: last)
+                            var arr = result[name] ?? []
+                            arr.append(fact)
+                            result[name] = arr
                         }
+                        single(.success(UserInfo(attributes: result)))
+                    } else if let error = error {
+                        single(.failure(error))
+                    } else {
+                        single(.success(nil))
                     }
-                    single(.success(UserInfo(attributes: attributes)))
-                } else if let error = error {
-                    single(.failure(error))
-                } else {
-                    single(.success(nil))
                 }
-            }
             return Disposables.create()
         }
     }
 
-    func update(uid: String, attributes: [String: String]) -> Single<Void> {
+    func update(uid: String, attributes: [String: [UserFact]]) -> Single<Void> {
         guard !attributes.isEmpty else { return .just(()) }
         return Single.create { single in
-            var data: [String: Any] = [:]
-            attributes.forEach { key, value in
-                data[key] = value
-            }
-            self.db.collection("userInfo").document(uid).setData(data, merge: true) { error in
-                if let error = error {
-                    single(.failure(error))
-                } else {
-                    single(.success(()))
+            let batch = self.db.batch()
+            for (name, facts) in attributes {
+                for fact in facts {
+                    let doc = self.db.collection("profiles")
+                        .document(uid)
+                        .collection("facts")
+                        .document("\(name)-\(fact.value)")
+                    let data: [String: Any] = [
+                        "name": name,
+                        "value": fact.value,
+                        "count": fact.count,
+                        "firstMentioned": fact.firstMentioned,
+                        "lastMentioned": fact.lastMentioned
+                    ]
+                    batch.setData(data, forDocument: doc, merge: true)
                 }
+            }
+            batch.commit { error in
+                if let error = error { single(.failure(error)) }
+                else { single(.success(())) }
             }
             return Disposables.create()
         }

--- a/chatGPT/Domain/Entity/PreferenceAnalysisResult.swift
+++ b/chatGPT/Domain/Entity/PreferenceAnalysisResult.swift
@@ -13,12 +13,57 @@ struct PreferenceAnalysisResult: Codable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let attributes = try container.decode([String: String].self, forKey: .info)
+        let infoContainer = try container.nestedContainer(keyedBy: DynamicCodingKey.self, forKey: .info)
+        var attributes: [String: [UserFact]] = [:]
+        let now = Date().timeIntervalSince1970
+        for key in infoContainer.allKeys {
+            if var arr = try? infoContainer.nestedUnkeyedContainer(forKey: key) {
+                var facts: [UserFact] = []
+                while !arr.isAtEnd {
+                    if let str = try? arr.decode(String.self) {
+                        facts.append(UserFact(value: str, count: 1, firstMentioned: now, lastMentioned: now))
+                    } else if let intVal = try? arr.decode(Int.self) {
+                        facts.append(UserFact(value: "\(intVal)", count: 1, firstMentioned: now, lastMentioned: now))
+                    } else if let dblVal = try? arr.decode(Double.self) {
+                        facts.append(UserFact(value: "\(dblVal)", count: 1, firstMentioned: now, lastMentioned: now))
+                    } else if let boolVal = try? arr.decode(Bool.self) {
+                        facts.append(UserFact(value: "\(boolVal)", count: 1, firstMentioned: now, lastMentioned: now))
+                    } else {
+                        _ = try? arr.decode(String.self)
+                    }
+                }
+                attributes[key.stringValue] = facts
+            } else if let str = try? infoContainer.decode(String.self, forKey: key) {
+                attributes[key.stringValue] = [UserFact(value: str, count: 1, firstMentioned: now, lastMentioned: now)]
+            } else if let intVal = try? infoContainer.decode(Int.self, forKey: key) {
+                attributes[key.stringValue] = [UserFact(value: "\(intVal)", count: 1, firstMentioned: now, lastMentioned: now)]
+            } else if let dblVal = try? infoContainer.decode(Double.self, forKey: key) {
+                attributes[key.stringValue] = [UserFact(value: "\(dblVal)", count: 1, firstMentioned: now, lastMentioned: now)]
+            } else if let boolVal = try? infoContainer.decode(Bool.self, forKey: key) {
+                attributes[key.stringValue] = [UserFact(value: "\(boolVal)", count: 1, firstMentioned: now, lastMentioned: now)]
+            }
+        }
         self.info = UserInfo(attributes: attributes)
     }
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(info.attributes, forKey: .info)
+        var infoContainer = container.nestedContainer(keyedBy: DynamicCodingKey.self, forKey: .info)
+        for (key, facts) in info.attributes {
+            let codingKey = DynamicCodingKey(stringValue: key)
+            if facts.count == 1 {
+                try infoContainer.encode(facts[0].value, forKey: codingKey)
+            } else {
+                var arr = infoContainer.nestedUnkeyedContainer(forKey: codingKey)
+                for fact in facts { try arr.encode(fact.value) }
+            }
+        }
     }
+}
+
+private struct DynamicCodingKey: CodingKey {
+    var stringValue: String
+    init(stringValue: String) { self.stringValue = stringValue }
+    var intValue: Int? { nil }
+    init?(intValue: Int) { return nil }
 }

--- a/chatGPT/Domain/Entity/UserFact.swift
+++ b/chatGPT/Domain/Entity/UserFact.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct UserFact: Codable, Equatable {
+    var value: String
+    var count: Int
+    var firstMentioned: TimeInterval
+    var lastMentioned: TimeInterval
+}

--- a/chatGPT/Domain/Entity/UserInfo.swift
+++ b/chatGPT/Domain/Entity/UserInfo.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 struct UserInfo: Codable, Equatable {
-    var attributes: [String: String]
+    var attributes: [String: [UserFact]]
 }

--- a/chatGPT/Domain/Repository/UserInfoRepository.swift
+++ b/chatGPT/Domain/Repository/UserInfoRepository.swift
@@ -3,5 +3,5 @@ import RxSwift
 
 protocol UserInfoRepository {
     func fetch(uid: String) -> Single<UserInfo?>
-    func update(uid: String, attributes: [String: String]) -> Single<Void>
+    func update(uid: String, attributes: [String: [UserFact]]) -> Single<Void>
 }

--- a/chatGPT/Presentation/Scene/ChatViewModel.swift
+++ b/chatGPT/Presentation/Scene/ChatViewModel.swift
@@ -272,7 +272,10 @@ final class ChatViewModel {
     func infoText(from info: UserInfo) -> String? {
         let parts = info.attributes
             .sorted { $0.key < $1.key }
-            .map { "\($0.key): \($0.value)" }
+            .map { key, facts in
+                let values = facts.map { $0.value }.joined(separator: ", ")
+                return "\(key): \(values)"
+            }
         return parts.isEmpty ? nil : parts.joined(separator: ", ")
     }
     

--- a/chatGPTTests/AnalyzeUserInputUseCaseTests.swift
+++ b/chatGPTTests/AnalyzeUserInputUseCaseTests.swift
@@ -3,9 +3,9 @@ import RxSwift
 @testable import chatGPT
 
 final class StubInfoRepository: UserInfoRepository {
-    private(set) var updated: [String: String] = [:]
+    private(set) var updated: [String: [UserFact]] = [:]
     func fetch(uid: String) -> Single<UserInfo?> { .just(nil) }
-    func update(uid: String, attributes: [String : String]) -> Single<Void> {
+    func update(uid: String, attributes: [String : [UserFact]]) -> Single<Void> {
         updated = attributes
         return .just(())
     }
@@ -50,13 +50,15 @@ final class AnalyzeUserInputUseCaseTests: XCTestCase {
 
     func test_updates_info() {
         openAI.analysisResult = PreferenceAnalysisResult(
-            info: UserInfo(attributes: ["drink": "coffee"])
+            info: UserInfo(attributes: [
+                "drink": [UserFact(value: "coffee", count: 1, firstMentioned: 0, lastMentioned: 0)]
+            ])
         )
         let exp = expectation(description: "update")
         useCase.execute(prompt: "I like coffee")
             .subscribe(onSuccess: { exp.fulfill() })
             .disposed(by: disposeBag)
         waitForExpectations(timeout: 1)
-        XCTAssertEqual(infoRepo.updated["drink"], "coffee")
+        XCTAssertEqual(infoRepo.updated["drink"]?.first?.value, "coffee")
     }
 }

--- a/chatGPTTests/ChatViewModelPreferenceTextTests.swift
+++ b/chatGPTTests/ChatViewModelPreferenceTextTests.swift
@@ -82,10 +82,10 @@ final class ChatViewModelPreferenceTextTests: XCTestCase {
             detectImageRequestUseCase: StubDetectImageRequestUseCase()
         )
         let info = UserInfo(attributes: [
-            "age": "20",
-            "gender": "male",
-            "job": "student",
-            "interest": "game"
+            "age": [UserFact(value: "20", count: 1, firstMentioned: 0, lastMentioned: 0)],
+            "gender": [UserFact(value: "male", count: 1, firstMentioned: 0, lastMentioned: 0)],
+            "job": [UserFact(value: "student", count: 1, firstMentioned: 0, lastMentioned: 0)],
+            "interest": [UserFact(value: "game", count: 1, firstMentioned: 0, lastMentioned: 0)]
         ])
         let text = vm.infoText(from: info)
         XCTAssertEqual(text, "age: 20, gender: male, interest: game, job: student")

--- a/chatGPTTests/FirestoreUserInfoRepositoryTests.swift
+++ b/chatGPTTests/FirestoreUserInfoRepositoryTests.swift
@@ -14,12 +14,14 @@ final class FirestoreUserInfoRepositoryTests: XCTestCase {
         let firestore = Firestore()
         let repository = FirestoreUserInfoRepository(db: firestore)
         let exp = expectation(description: "update")
-        repository.update(uid: "u1", attributes: ["age": "20"])
+        let fact = UserFact(value: "20", count: 1, firstMentioned: 0, lastMentioned: 0)
+        repository.update(uid: "u1", attributes: ["age": [fact]])
             .subscribe(onSuccess: { exp.fulfill() })
             .disposed(by: disposeBag)
         waitForExpectations(timeout: 1)
         let call = firestore.lastBatch?.setCalls.first
-        XCTAssertEqual(call?.document.path, "userInfo/u1")
-        XCTAssertEqual(call?.data["age"] as? String, "20")
+        XCTAssertEqual(call?.document.path, "profiles/u1/facts/age-20")
+        XCTAssertEqual(call?.data["name"] as? String, "age")
+        XCTAssertEqual(call?.data["value"] as? String, "20")
     }
 }

--- a/chatGPTTests/PreferenceAnalysisResultTests.swift
+++ b/chatGPTTests/PreferenceAnalysisResultTests.swift
@@ -3,9 +3,10 @@ import XCTest
 
 final class PreferenceAnalysisResultTests: XCTestCase {
     func test_decoding() throws {
-        let json = #"{"info":{"occupation":"iOS developer"}}"#
+        let json = #"{"info":{"occupation":"iOS developer","likes":["swift"]}}"#
         let data = Data(json.utf8)
         let result = try JSONDecoder().decode(PreferenceAnalysisResult.self, from: data)
-        XCTAssertEqual(result.info.attributes["occupation"], "iOS developer")
+        XCTAssertEqual(result.info.attributes["occupation"]?.first?.value, "iOS developer")
+        XCTAssertEqual(result.info.attributes["likes"]?.first?.value, "swift")
     }
 }


### PR DESCRIPTION
## Summary
- introduce `UserFact` for storing history
- update `UserInfo` to hold multiple `UserFact`s
- parse analysis results into these facts
- persist user facts as separate documents
- merge new facts when analyzing user input
- update repository interface and implementation

## Testing
- `swift test` *(fails: unable to clone RxSwift)*

------
https://chatgpt.com/codex/tasks/task_e_688cb90100fc832b90db3b80ff4398c7