### PR TITLE
Implement user info fetch

### DIFF
--- a/chatGPTTests/FirebaseFirestoreStubs.swift
+++ b/chatGPTTests/FirebaseFirestoreStubs.swift
@@ -13,6 +13,15 @@ class CollectionReference {
     init(store: Firestore, path: String) { self.store = store; self.path = path }
     func document(_ id: String) -> DocumentReference { DocumentReference(store: store, path: "\(path)/\(id)") }
     func collection(_ id: String) -> CollectionReference { CollectionReference(store: store, path: "\(path)/\(id)") }
+    func getDocuments(completion: (QuerySnapshot?, Error?) -> Void) {
+        let prefix = path + "/"
+        var docs: [QueryDocumentSnapshot] = []
+        for (key, value) in store.documents where key.hasPrefix(prefix) {
+            let id = String(key.dropFirst(prefix.count))
+            docs.append(QueryDocumentSnapshot(documentID: id, data: value))
+        }
+        completion(QuerySnapshot(documents: docs), nil)
+    }
 }
 
 class DocumentReference {
@@ -47,6 +56,21 @@ class DocumentSnapshot {
     init(data: [String: Any]?) { self.dataMap = data }
     var exists: Bool { dataMap != nil }
     func data() -> [String: Any]? { dataMap }
+}
+
+class QueryDocumentSnapshot {
+    let documentID: String
+    private let dataMap: [String: Any]
+    init(documentID: String, data: [String: Any]) {
+        self.documentID = documentID
+        self.dataMap = data
+    }
+    func data() -> [String: Any] { dataMap }
+}
+
+class QuerySnapshot {
+    let documents: [QueryDocumentSnapshot]
+    init(documents: [QueryDocumentSnapshot]) { self.documents = documents }
 }
 
 class FieldValue {

--- a/chatGPTTests/FirestoreUserInfoRepositoryTests.swift
+++ b/chatGPTTests/FirestoreUserInfoRepositoryTests.swift
@@ -57,4 +57,30 @@ final class FirestoreUserInfoRepositoryTests: XCTestCase {
         XCTAssertEqual(doc?["count"] as? Int, 2)
         XCTAssertEqual(doc?["canonicalValue"] as? String, "udon")
     }
+
+    func test_fetch_returns_user_info() {
+        let firestore = Firestore()
+        firestore.documents["profiles/u1/facts/udon"] = [
+            "name": "likes",
+            "value": "udon",
+            "canonicalValue": "udon",
+            "count": 2,
+            "firstMentioned": 100.0,
+            "lastMentioned": 200.0
+        ]
+        let repository = FirestoreUserInfoRepository(db: firestore)
+
+        let exp = expectation(description: "fetch")
+        var result: UserInfo?
+        repository.fetch(uid: "u1")
+            .subscribe(onSuccess: { info in
+                result = info
+                exp.fulfill()
+            })
+            .disposed(by: disposeBag)
+        waitForExpectations(timeout: 1)
+
+        let expectedFact = UserFact(value: "udon", count: 2, firstMentioned: 100, lastMentioned: 200)
+        XCTAssertEqual(result, UserInfo(attributes: ["likes": [expectedFact]]))
+    }
 }


### PR DESCRIPTION
## Summary
- implement fetch to read user facts from Firestore
- support getDocuments in Firestore test stub
- add test for fetching user info

## Testing
- `swift test` *(fails: unable to access 'https://github.com/ReactiveX/RxSwift.git/' due to CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_6890a9d7dcf4832ba4e13d70bb679b75