### PR TITLE
Add realtime user info sync

### DIFF
--- a/chatGPT/Domain/Repository/UserInfoRepository.swift
+++ b/chatGPT/Domain/Repository/UserInfoRepository.swift
@@ -3,5 +3,6 @@ import RxSwift
 
 protocol UserInfoRepository {
     func fetch(uid: String) -> Single<UserInfo?>
+    func observe(uid: String) -> Observable<UserInfo?>
     func update(uid: String, attributes: [String: [UserFact]]) -> Single<Void>
 }

--- a/chatGPT/Domain/UseCase/FetchUserInfoUseCase.swift
+++ b/chatGPT/Domain/UseCase/FetchUserInfoUseCase.swift
@@ -14,4 +14,9 @@ final class FetchUserInfoUseCase {
         guard let user = getCurrentUserUseCase.execute() else { return .just(nil) }
         return repository.fetch(uid: user.uid)
     }
+
+    func observe() -> Observable<UserInfo?> {
+        guard let user = getCurrentUserUseCase.execute() else { return .just(nil) }
+        return repository.observe(uid: user.uid)
+    }
 }

--- a/chatGPTTests/AnalyzeUserInputUseCaseTests.swift
+++ b/chatGPTTests/AnalyzeUserInputUseCaseTests.swift
@@ -5,6 +5,7 @@ import RxSwift
 final class StubInfoRepository: UserInfoRepository {
     private(set) var updated: [String: [UserFact]] = [:]
     func fetch(uid: String) -> Single<UserInfo?> { .just(nil) }
+    func observe(uid: String) -> Observable<UserInfo?> { .empty() }
     func update(uid: String, attributes: [String : [UserFact]]) -> Single<Void> {
         updated = attributes
         return .just(())

--- a/chatGPTTests/FirebaseFirestoreStubs.swift
+++ b/chatGPTTests/FirebaseFirestoreStubs.swift
@@ -22,6 +22,17 @@ class CollectionReference {
         }
         completion(QuerySnapshot(documents: docs), nil)
     }
+
+    func addSnapshotListener(_ listener: @escaping (QuerySnapshot?, Error?) -> Void) -> ListenerRegistration {
+        let prefix = path + "/"
+        var docs: [QueryDocumentSnapshot] = []
+        for (key, value) in store.documents where key.hasPrefix(prefix) {
+            let id = String(key.dropFirst(prefix.count))
+            docs.append(QueryDocumentSnapshot(documentID: id, data: value))
+        }
+        listener(QuerySnapshot(documents: docs), nil)
+        return ListenerRegistration {}
+    }
 }
 
 class DocumentReference {
@@ -75,4 +86,10 @@ class QuerySnapshot {
 
 class FieldValue {
     static func increment(_ value: Int64) -> Int64 { value }
+}
+
+class ListenerRegistration {
+    private let onRemove: () -> Void
+    init(_ onRemove: @escaping () -> Void) { self.onRemove = onRemove }
+    func remove() { onRemove() }
 }


### PR DESCRIPTION
## Summary
- watch Firestore user info with snapshot listener
- refresh cached info after updates via Rx flatMapLatest

## Testing
- `swift test` *(failed: Failed to clone repository https://github.com/ReactiveX/RxSwift.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6891dd4999ac832ba2f16bd7833a097a