### PR TITLE
Add user memory and context builder

### DIFF
--- a/chatGPT.xcodeproj/project.pbxproj
+++ b/chatGPT.xcodeproj/project.pbxproj
@@ -67,9 +67,10 @@
 		F164B1062E3CD4FD00D8DABA /* UserInfoRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = F164B1052E3CD4FD00D8DABA /* UserInfoRepository.swift */; };
 		F164B1092E3CD51100D8DABA /* UpdateUserInfoUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = F164B1082E3CD51100D8DABA /* UpdateUserInfoUseCase.swift */; };
 		F164B10A2E3CD51100D8DABA /* FetchUserInfoUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = F164B1072E3CD51100D8DABA /* FetchUserInfoUseCase.swift */; };
-		F164B10F2E3CD52500D8DABA /* FirestoreUserInfoRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F164B10D2E3CD52500D8DABA /* FirestoreUserInfoRepositoryTests.swift */; };
-		F164B1112E3CD52500D8DABA /* ChatContextRepositoryImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F164B10C2E3CD52500D8DABA /* ChatContextRepositoryImplTests.swift */; };
-		F164B1152E3CD57900D8DABA /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = F164B1132E3CD57900D8DABA /* Localizable.strings */; };
+F164B10F2E3CD52500D8DABA /* FirestoreUserInfoRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F164B10D2E3CD52500D8DABA /* FirestoreUserInfoRepositoryTests.swift */; };
+F164B1112E3CD52500D8DABA /* ChatContextRepositoryImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F164B10C2E3CD52500D8DABA /* ChatContextRepositoryImplTests.swift */; };
+D08E9B032CA34FCC995B5105 /* UserContextBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BDFC348FD9941E0B237914D /* UserContextBuilderTests.swift */; };
+F164B1152E3CD57900D8DABA /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = F164B1132E3CD57900D8DABA /* Localizable.strings */; };
 		F164B1172E3CD66800D8DABA /* FirestoreUserInfoRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = F164B1162E3CD66800D8DABA /* FirestoreUserInfoRepository.swift */; };
 		F166CA132DF9A39B00AAB5B0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F166CA0B2DF9A39B00AAB5B0 /* AppDelegate.swift */; };
 		F166CA142DF9A39B00AAB5B0 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F166CA102DF9A39B00AAB5B0 /* SceneDelegate.swift */; };
@@ -86,8 +87,10 @@
 		F18040AF2E25175E009B8527 /* RemoteImageAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18040AC2E25175E009B8527 /* RemoteImageAttachment.swift */; };
 		F18040B02E251760009B8527 /* RemoteImageGroupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18040B12E251760009B8527 /* RemoteImageGroupView.swift */; };
 		F18040B22E251760009B8527 /* RemoteImageGroupAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18040B32E251760009B8527 /* RemoteImageGroupAttachment.swift */; };
-		F18F0CEA2E3B80090055D516 /* AnalyzeUserInputUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18F0CE92E3B80090055D516 /* AnalyzeUserInputUseCase.swift */; };
-		F196CB2B2E152D3400814FD5 /* PaddedLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F196CB2A2E152D3400814FD5 /* PaddedLabel.swift */; };
+                F18F0CEA2E3B80090055D516 /* AnalyzeUserInputUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18F0CE92E3B80090055D516 /* AnalyzeUserInputUseCase.swift */; };
+                F196CB2B2E152D3400814FD5 /* PaddedLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F196CB2A2E152D3400814FD5 /* PaddedLabel.swift */; };
+                F20000042F10001000000003 /* UserMemoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F20000032F10001000000003 /* UserMemoryStore.swift */; };
+                F20000062F10001000000004 /* UserContextBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = F20000052F10001000000004 /* UserContextBuilder.swift */; };
 		F19F74312DFC57E6007AB4C1 /* ChatComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F19F74302DFC57E6007AB4C1 /* ChatComposerView.swift */; };
 		F1B7F7602DF9DC68002D12BB /* LinkLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1B7F75F2DF9DC68002D12BB /* LinkLabel.swift */; };
 		F1B7F7632DF9E541002D12BB /* KeyboardAdjustable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1B7F7622DF9E541002D12BB /* KeyboardAdjustable.swift */; };
@@ -171,8 +174,9 @@
 		79766A3D81B253405488FCA1 /* AppendMessageUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppendMessageUseCase.swift; sourceTree = "<group>"; };
 		7E3AE2342A568CE6890C03F0 /* CodeBlockAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeBlockAttachment.swift; sourceTree = "<group>"; };
 		7b5d4e4a1234567800000001 /* PreferenceAnalysisResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferenceAnalysisResult.swift; sourceTree = "<group>"; };
-		7b5d4f1234567800000006 /* AnalyzeUserInputUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyzeUserInputUseCaseTests.swift; sourceTree = "<group>"; };
-		7d4726864e6840b090b6e407 /* KingfisherImageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KingfisherImageRepository.swift; sourceTree = "<group>"; };
+7b5d4f1234567800000006 /* AnalyzeUserInputUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyzeUserInputUseCaseTests.swift; sourceTree = "<group>"; };
+8BDFC348FD9941E0B237914D /* UserContextBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserContextBuilderTests.swift; sourceTree = "<group>"; };
+7d4726864e6840b090b6e407 /* KingfisherImageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KingfisherImageRepository.swift; sourceTree = "<group>"; };
 		896db1fb7f9843dbb43a9831 /* SignOutUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignOutUseCase.swift; sourceTree = "<group>"; };
 		9b8f82223d524f878b330338 /* ObserveAuthStateUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObserveAuthStateUseCase.swift; sourceTree = "<group>"; };
 		A1D564E2F8AC41B39D235947 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
@@ -245,9 +249,11 @@
 		F18040AD2E25175E009B8527 /* RemoteImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteImageView.swift; sourceTree = "<group>"; };
 		F18040B12E251760009B8527 /* RemoteImageGroupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteImageGroupView.swift; sourceTree = "<group>"; };
 		F18040B32E251760009B8527 /* RemoteImageGroupAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteImageGroupAttachment.swift; sourceTree = "<group>"; };
-		F18F0CE92E3B80090055D516 /* AnalyzeUserInputUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyzeUserInputUseCase.swift; sourceTree = "<group>"; };
-		F196CB2A2E152D3400814FD5 /* PaddedLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddedLabel.swift; sourceTree = "<group>"; };
-		F19F74302DFC57E6007AB4C1 /* ChatComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposerView.swift; sourceTree = "<group>"; };
+                F18F0CE92E3B80090055D516 /* AnalyzeUserInputUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyzeUserInputUseCase.swift; sourceTree = "<group>"; };
+                F196CB2A2E152D3400814FD5 /* PaddedLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddedLabel.swift; sourceTree = "<group>"; };
+                F20000032F10001000000003 /* UserMemoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserMemoryStore.swift; sourceTree = "<group>"; };
+                F20000052F10001000000004 /* UserContextBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserContextBuilder.swift; sourceTree = "<group>"; };
+                F19F74302DFC57E6007AB4C1 /* ChatComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposerView.swift; sourceTree = "<group>"; };
 		F1B7F75F2DF9DC68002D12BB /* LinkLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkLabel.swift; sourceTree = "<group>"; };
 		F1B7F7622DF9E541002D12BB /* KeyboardAdjustable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardAdjustable.swift; sourceTree = "<group>"; };
 		F1BFC8342E38FF8400FF3DA6 /* OpenAITranslationRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAITranslationRepository.swift; sourceTree = "<group>"; };
@@ -433,14 +439,15 @@
 			children = (
 				F164B10C2E3CD52500D8DABA /* ChatContextRepositoryImplTests.swift */,
 				F164B10D2E3CD52500D8DABA /* FirestoreUserInfoRepositoryTests.swift */,
-				F1F4CC3E2E39198000690C4D /* FirebaseFirestoreStubs.swift */,
-				7b5d4f1234567800000006 /* AnalyzeUserInputUseCaseTests.swift */,
-				F1D772CD2E321FBD006F749A /* DetectImageRequestUseCaseTests.swift */,
-				F166CA192DF9A3A300AAB5B0 /* chatGPTTests.swift */,
-			);
-			path = chatGPTTests;
-			sourceTree = "<group>";
-		};
+                F1F4CC3E2E39198000690C4D /* FirebaseFirestoreStubs.swift */,
+                7b5d4f1234567800000006 /* AnalyzeUserInputUseCaseTests.swift */,
+                F1D772CD2E321FBD006F749A /* DetectImageRequestUseCaseTests.swift */,
+                8BDFC348FD9941E0B237914D /* UserContextBuilderTests.swift */,
+                F166CA192DF9A3A300AAB5B0 /* chatGPTTests.swift */,
+        );
+        path = chatGPTTests;
+        sourceTree = "<group>";
+}; 
 		F166CA1E2DF9A3A500AAB5B0 /* chatGPTUITests */ = {
 			isa = PBXGroup;
 			children = (
@@ -469,11 +476,12 @@
 				F1DE5A772E094C37001B0CA8 /* FirebaseAuthRepository.swift */,
 				F1DF3B022DF9AF7B00D8445A /* KeychainAPIKeyRepository.swift */,
 				F117E0742E0184A900D1C95F /* OpenAIRepository.swift */,
-				F117E0762E0184FF00D1C95F /* OpenAIRepositoryImpl.swift */,
-				d3ab64ef73ac4fbca561c2f3 /* ChatContextRepositoryImpl.swift */,
-				7d4726864e6840b090b6e407 /* KingfisherImageRepository.swift */,
-				F20000012F00000200000002 /* FirebaseFileRepository.swift */,
-			);
+                                F117E0762E0184FF00D1C95F /* OpenAIRepositoryImpl.swift */,
+                                d3ab64ef73ac4fbca561c2f3 /* ChatContextRepositoryImpl.swift */,
+                                7d4726864e6840b090b6e407 /* KingfisherImageRepository.swift */,
+                                F20000012F00000200000002 /* FirebaseFileRepository.swift */,
+                                F20000032F10001000000003 /* UserMemoryStore.swift */,
+                        );
 			path = Data;
 			sourceTree = "<group>";
 		};
@@ -529,11 +537,12 @@
 				eef3624df55348a684cdc5fd /* LoadUserProfileImageUseCase.swift */,
 				9b8f82223d524f878b330338 /* ObserveAuthStateUseCase.swift */,
 				79766A3D81B253405488FCA1 /* AppendMessageUseCase.swift */,
-				F20000032F00000300000003 /* UploadFilesUseCase.swift */,
-				3e924cb7e10d40a1a28fc225 /* ObserveConversationsUseCase.swift */,
-				D1429C4B96A13E73C35752E4 /* UpdateConversationTitleUseCase.swift */,
-				64EB7DD9103C65295FB89E7C /* DeleteConversationUseCase.swift */,
-			);
+                                F20000032F00000300000003 /* UploadFilesUseCase.swift */,
+                                3e924cb7e10d40a1a28fc225 /* ObserveConversationsUseCase.swift */,
+                                D1429C4B96A13E73C35752E4 /* UpdateConversationTitleUseCase.swift */,
+                                64EB7DD9103C65295FB89E7C /* DeleteConversationUseCase.swift */,
+                                F20000052F10001000000004 /* UserContextBuilder.swift */,
+                        );
 			path = UseCase;
 			sourceTree = "<group>";
 		};
@@ -895,14 +904,15 @@
 		F16563DA2DF9A310001CDF3B /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
-			files = (
-				F164B10F2E3CD52500D8DABA /* FirestoreUserInfoRepositoryTests.swift in Sources */,
-				F164B1112E3CD52500D8DABA /* ChatContextRepositoryImplTests.swift in Sources */,
-				F1D772CE2E321FBD006F749A /* DetectImageRequestUseCaseTests.swift in Sources */,
-				7b5d4e4e1234567800000005 /* (null) in Sources */,
-				F166CA1B2DF9A3A300AAB5B0 /* chatGPTTests.swift in Sources */,
-				F1F4CC422E39198000690C4D /* FirebaseFirestoreStubs.swift in Sources */,
-			);
+                        files = (
+                                F164B10F2E3CD52500D8DABA /* FirestoreUserInfoRepositoryTests.swift in Sources */,
+                                F164B1112E3CD52500D8DABA /* ChatContextRepositoryImplTests.swift in Sources */,
+                                F1D772CE2E321FBD006F749A /* DetectImageRequestUseCaseTests.swift in Sources */,
+                                D08E9B032CA34FCC995B5105 /* UserContextBuilderTests.swift in Sources */,
+                                7b5d4e4e1234567800000005 /* (null) in Sources */,
+                                F166CA1B2DF9A3A300AAB5B0 /* chatGPTTests.swift in Sources */,
+                                F1F4CC422E39198000690C4D /* FirebaseFirestoreStubs.swift in Sources */,
+                        );
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		F16563E42DF9A310001CDF3B /* Sources */ = {

--- a/chatGPT/Data/FirestoreUserInfoRepository.swift
+++ b/chatGPT/Data/FirestoreUserInfoRepository.swift
@@ -44,12 +44,15 @@ final class FirestoreUserInfoRepository: UserInfoRepository {
         }
     }
 
-    func observe(uid: String) -> Observable<UserInfo?> {
+    func observe(uid: String, since: TimeInterval?) -> Observable<UserInfo?> {
         Observable.create { observer in
-            let listener = self.db.collection("profiles")
+            var query: Query = self.db.collection("profiles")
                 .document(uid)
                 .collection("facts")
-                .addSnapshotListener { snapshot, error in
+            if let since {
+                query = query.whereField("lastMentioned", isGreaterThan: since)
+            }
+            let listener = query.addSnapshotListener { snapshot, error in
                     if let error = error {
                         observer.onError(error)
                         return

--- a/chatGPT/Data/UserMemoryStore.swift
+++ b/chatGPT/Data/UserMemoryStore.swift
@@ -1,0 +1,43 @@
+import Foundation
+import RxSwift
+import RxRelay
+
+final class UserMemoryStore {
+    static let shared = UserMemoryStore()
+    private let relay = BehaviorRelay<UserInfo?>(value: nil)
+    private let disposeBag = DisposeBag()
+    private let ttl: TimeInterval = 60 * 60 * 24 * 365 // 1 year
+
+    var info: UserInfo? { relay.value }
+    var latestTimestamp: TimeInterval? {
+        info?.attributes.values
+            .flatMap { $0 }
+            .map { $0.lastMentioned }
+            .max()
+    }
+
+    func bind(_ observable: Observable<UserInfo?>) {
+        observable
+            .compactMap { $0 }
+            .subscribe(onNext: { [weak self] info in
+                self?.update(info)
+            })
+            .disposed(by: disposeBag)
+    }
+
+    func asObservable() -> Observable<UserInfo?> {
+        relay.asObservable()
+    }
+
+    private func update(_ info: UserInfo) {
+        let now = Date().timeIntervalSince1970
+        var filtered: [String: [UserFact]] = [:]
+        for (key, facts) in info.attributes {
+            let valid = facts.filter { now - $0.lastMentioned < ttl }
+            if !valid.isEmpty {
+                filtered[key] = valid
+            }
+        }
+        relay.accept(UserInfo(attributes: filtered))
+    }
+}

--- a/chatGPT/Domain/Repository/UserInfoRepository.swift
+++ b/chatGPT/Domain/Repository/UserInfoRepository.swift
@@ -3,6 +3,6 @@ import RxSwift
 
 protocol UserInfoRepository {
     func fetch(uid: String) -> Single<UserInfo?>
-    func observe(uid: String) -> Observable<UserInfo?>
+    func observe(uid: String, since: TimeInterval?) -> Observable<UserInfo?>
     func update(uid: String, attributes: [String: [UserFact]]) -> Single<Void>
 }

--- a/chatGPT/Domain/UseCase/UserContextBuilder.swift
+++ b/chatGPT/Domain/UseCase/UserContextBuilder.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+final class UserContextBuilder {
+    private let store: UserMemoryStore
+    private let maxAttributes: Int
+
+    init(store: UserMemoryStore = .shared, maxAttributes: Int = 3) {
+        self.store = store
+        self.maxAttributes = maxAttributes
+    }
+
+    func buildProfile(for prompt: String) -> String? {
+        guard let info = store.info else { return nil }
+        let lower = prompt.lowercased()
+        var selected: [String: [UserFact]] = [:]
+        // pick attributes mentioned in the prompt
+        for (key, facts) in info.attributes {
+            if lower.contains(key.lowercased()) {
+                selected[key] = facts
+            }
+        }
+        // fill remaining slots with most frequent attributes
+        if selected.count < maxAttributes {
+            let sorted = info.attributes
+                .sorted { lhs, rhs in
+                    let l = lhs.value.map { $0.count }.reduce(0, +)
+                    let r = rhs.value.map { $0.count }.reduce(0, +)
+                    return l > r
+                }
+            for (key, facts) in sorted where selected[key] == nil && selected.count < maxAttributes {
+                selected[key] = facts
+            }
+        }
+        guard !selected.isEmpty else { return nil }
+        let parts = selected
+            .sorted { $0.key < $1.key }
+            .map { key, facts in
+                let values = facts.map { $0.value }.joined(separator: ", ")
+                return "\(key): \(values)"
+            }
+        return parts.joined(separator: ", ")
+    }
+}

--- a/chatGPT/Presentation/Coordinator/AppCoordinator.swift
+++ b/chatGPT/Presentation/Coordinator/AppCoordinator.swift
@@ -59,13 +59,15 @@ final class AppCoordinator {
             summarizeUseCase: summarizeUseCase
         )
         let getCurrentUserUseCase = GetCurrentUserUseCase(repository: authRepository)
-        
+
         let infoRepository = FirestoreUserInfoRepository()
         _ = OpenAITranslationRepository(repository: repository)
+        let memoryStore = UserMemoryStore()
 
         let fetchInfoUseCase = FetchUserInfoUseCase(
             repository: infoRepository,
-            getCurrentUserUseCase: getCurrentUserUseCase
+            getCurrentUserUseCase: getCurrentUserUseCase,
+            memoryStore: memoryStore
         )
         let updateInfoUseCase = UpdateUserInfoUseCase(
             repository: infoRepository,
@@ -76,6 +78,7 @@ final class AppCoordinator {
             infoRepository: infoRepository,
             getCurrentUserUseCase: getCurrentUserUseCase
         )
+        let contextBuilder = UserContextBuilder(store: memoryStore)
         let conversationRepository = FirestoreConversationRepository()
         
         let saveConversationUseCase = SaveConversationUseCase(
@@ -140,7 +143,8 @@ final class AppCoordinator {
             updateInfoUseCase: updateInfoUseCase,
             uploadFilesUseCase: uploadFilesUseCase,
             generateImageUseCase: generateImageUseCase,
-            detectImageRequestUseCase: detectImageRequestUseCase
+            detectImageRequestUseCase: detectImageRequestUseCase,
+            contextBuilder: contextBuilder
         )
         
         let nav = UINavigationController(rootViewController: vc)

--- a/chatGPT/Presentation/Scene/MainViewController.swift
+++ b/chatGPT/Presentation/Scene/MainViewController.swift
@@ -158,7 +158,8 @@ final class MainViewController: UIViewController {
          updateInfoUseCase: UpdateUserInfoUseCase,
          uploadFilesUseCase: UploadFilesUseCase,
          generateImageUseCase: GenerateImageUseCase,
-         detectImageRequestUseCase: DetectImageRequestUseCase) {
+         detectImageRequestUseCase: DetectImageRequestUseCase,
+         contextBuilder: UserContextBuilder) {
         self.fetchModelsUseCase = fetchModelsUseCase
         self.chatViewModel = ChatViewModel(sendMessageUseCase: sendChatMessageUseCase,
                                            summarizeUseCase: summarizeUseCase,
@@ -170,7 +171,8 @@ final class MainViewController: UIViewController {
                                            fetchInfoUseCase: fetchInfoUseCase,
                                            uploadFilesUseCase: uploadFilesUseCase,
                                            generateImageUseCase: generateImageUseCase,
-                                           detectImageRequestUseCase: detectImageRequestUseCase)
+                                           detectImageRequestUseCase: detectImageRequestUseCase,
+                                           contextBuilder: contextBuilder)
         self.fetchConversationMessagesUseCase = fetchConversationMessagesUseCase
         self.signOutUseCase = signOutUseCase
         self.observeConversationsUseCase = observeConversationsUseCase

--- a/chatGPTTests/AnalyzeUserInputUseCaseTests.swift
+++ b/chatGPTTests/AnalyzeUserInputUseCaseTests.swift
@@ -5,7 +5,7 @@ import RxSwift
 final class StubInfoRepository: UserInfoRepository {
     private(set) var updated: [String: [UserFact]] = [:]
     func fetch(uid: String) -> Single<UserInfo?> { .just(nil) }
-    func observe(uid: String) -> Observable<UserInfo?> { .empty() }
+    func observe(uid: String, since: TimeInterval?) -> Observable<UserInfo?> { .empty() }
     func update(uid: String, attributes: [String : [UserFact]]) -> Single<Void> {
         updated = attributes
         return .just(())

--- a/chatGPTTests/FirebaseFirestoreStubs.swift
+++ b/chatGPTTests/FirebaseFirestoreStubs.swift
@@ -7,12 +7,15 @@ class Firestore {
     static func firestore() -> Firestore { Firestore() }
 }
 
+typealias Query = CollectionReference
+
 class CollectionReference {
     let store: Firestore
     let path: String
     init(store: Firestore, path: String) { self.store = store; self.path = path }
     func document(_ id: String) -> DocumentReference { DocumentReference(store: store, path: "\(path)/\(id)") }
     func collection(_ id: String) -> CollectionReference { CollectionReference(store: store, path: "\(path)/\(id)") }
+    func whereField(_ field: String, isGreaterThan value: TimeInterval) -> CollectionReference { self }
     func getDocuments(completion: (QuerySnapshot?, Error?) -> Void) {
         let prefix = path + "/"
         var docs: [QueryDocumentSnapshot] = []

--- a/chatGPTTests/UserContextBuilderTests.swift
+++ b/chatGPTTests/UserContextBuilderTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+import RxSwift
+@testable import chatGPT
+
+final class UserContextBuilderTests: XCTestCase {
+    func test_selects_attributes_in_prompt_and_top_by_count() {
+        let now = Date().timeIntervalSince1970
+        let store = UserMemoryStore()
+        let info = UserInfo(attributes: [
+            "age": [UserFact(value: "33", count: 5, firstMentioned: now - 1000, lastMentioned: now - 500)],
+            "color": [UserFact(value: "blue", count: 2, firstMentioned: now - 1000, lastMentioned: now - 500)],
+            "hobby": [UserFact(value: "chess", count: 3, firstMentioned: now - 1000, lastMentioned: now - 500)]
+        ])
+        store.bind(.just(info))
+        let builder = UserContextBuilder(store: store, maxAttributes: 2)
+        let profile = builder.buildProfile(for: "tell me your hobby")
+        XCTAssertEqual(profile, "age: 33, hobby: chess")
+    }
+
+    func test_falls_back_to_top_attributes_when_prompt_has_no_match() {
+        let now = Date().timeIntervalSince1970
+        let store = UserMemoryStore()
+        let info = UserInfo(attributes: [
+            "color": [UserFact(value: "blue", count: 5, firstMentioned: now - 1000, lastMentioned: now - 500)],
+            "food": [UserFact(value: "sushi", count: 2, firstMentioned: now - 1000, lastMentioned: now - 500)]
+        ])
+        store.bind(.just(info))
+        let builder = UserContextBuilder(store: store, maxAttributes: 1)
+        let profile = builder.buildProfile(for: "hello")
+        XCTAssertEqual(profile, "color: blue")
+    }
+}


### PR DESCRIPTION
## Summary
- add in-memory user cache with TTL and context builder for prompt filtering
- filter Firestore observes by timestamp to limit updates
- wire context builder through coordinator and view layer
- select user profile attributes dynamically by relevance instead of hardcoded keys
- cover context builder selection logic with unit tests

## Testing
- `swift test` *(fails: unable to access 'https://github.com/ReactiveX/RxSwift.git/' due to CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_6891e174bbd4832b81d47f3ab71627a5