### PR TITLE
Refactor login and main view models

### DIFF
--- a/chatGPT.xcodeproj/project.pbxproj
+++ b/chatGPT.xcodeproj/project.pbxproj
@@ -42,8 +42,9 @@
 		F117E0752E0184A900D1C95F /* OpenAIRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = F117E0742E0184A900D1C95F /* OpenAIRepository.swift */; };
 		F117E0772E0184FF00D1C95F /* OpenAIRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = F117E0762E0184FF00D1C95F /* OpenAIRepositoryImpl.swift */; };
 		F117E0792E0185D100D1C95F /* SendChatMessageUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = F117E0782E0185D100D1C95F /* SendChatMessageUseCase.swift */; };
-		F117E07B2E0188F200D1C95F /* ChatViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F117E07A2E0188F200D1C95F /* ChatViewModel.swift */; };
-		F117E07E2E018B1000D1C95F /* ChatMessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F117E07D2E018B1000D1C95F /* ChatMessageCell.swift */; };
+                F117E07B2E0188F200D1C95F /* MainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F117E07A2E0188F200D1C95F /* MainViewModel.swift */; };
+                9A880C92584B44F1B4ABEA5E /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F7B59F5C42342358A876B11 /* LoginViewModel.swift */; };
+                F117E07E2E018B1000D1C95F /* ChatMessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F117E07D2E018B1000D1C95F /* ChatMessageCell.swift */; };
 		F12111112F0A000100D00000 /* HorizontalRuleAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12111102F0A000100D00000 /* HorizontalRuleAttachment.swift */; };
 		F12111132F0A000100D00000 /* HorizontalRuleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12111122F0A000100D00000 /* HorizontalRuleView.swift */; };
 		F122E5D22E0C034B006E81DD /* ConversationMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = F122E5D12E0C034B006E81DD /* ConversationMessage.swift */; };
@@ -199,7 +200,8 @@
 		F117E0742E0184A900D1C95F /* OpenAIRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAIRepository.swift; sourceTree = "<group>"; };
 		F117E0762E0184FF00D1C95F /* OpenAIRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAIRepositoryImpl.swift; sourceTree = "<group>"; };
 		F117E0782E0185D100D1C95F /* SendChatMessageUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendChatMessageUseCase.swift; sourceTree = "<group>"; };
-		F117E07A2E0188F200D1C95F /* ChatViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModel.swift; sourceTree = "<group>"; };
+            F117E07A2E0188F200D1C95F /* MainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewModel.swift; sourceTree = "<group>"; };
+            6F7B59F5C42342358A876B11 /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
 		F117E07D2E018B1000D1C95F /* ChatMessageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageCell.swift; sourceTree = "<group>"; };
 		F12111102F0A000100D00000 /* HorizontalRuleAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalRuleAttachment.swift; sourceTree = "<group>"; };
 		F12111122F0A000100D00000 /* HorizontalRuleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalRuleView.swift; sourceTree = "<group>"; };
@@ -406,15 +408,16 @@
 			path = ViewController;
 			sourceTree = "<group>";
 		};
-		F15F9E262E44B30E0062BCDA /* ViewModel */ = {
-			isa = PBXGroup;
-			children = (
-				194BF4C4E68B49E490052C9E /* MenuViewModel.swift */,
-				F117E07A2E0188F200D1C95F /* ChatViewModel.swift */,
-			);
-			path = ViewModel;
-			sourceTree = "<group>";
-		};
+                F15F9E262E44B30E0062BCDA /* ViewModel */ = {
+                        isa = PBXGroup;
+                        children = (
+                                194BF4C4E68B49E490052C9E /* MenuViewModel.swift */,
+                                6F7B59F5C42342358A876B11 /* LoginViewModel.swift */,
+                                F117E07A2E0188F200D1C95F /* MainViewModel.swift */,
+                        );
+                        path = ViewModel;
+                        sourceTree = "<group>";
+                };
 		F16563BF2DF9A30F001CDF3B = {
 			isa = PBXGroup;
 			children = (
@@ -835,9 +838,10 @@
 				F13DAC9A2E310EC4005A1A67 /* GenerateImageUseCase.swift in Sources */,
 				F1D52BC32E266CCF00239002 /* ImageViewerViewController.swift in Sources */,
 				FC3E2F78E32E01AD12EAC399 /* AppendMessageUseCase.swift in Sources */,
-				F117E0732E01847E00D1C95F /* FetchAvailableModelsUseCase.swift in Sources */,
-				F117E07B2E0188F200D1C95F /* ChatViewModel.swift in Sources */,
-				F17898942E1414AF000AEA35 /* TableBlockAttachment.swift in Sources */,
+                                F117E0732E01847E00D1C95F /* FetchAvailableModelsUseCase.swift in Sources */,
+                                F117E07B2E0188F200D1C95F /* MainViewModel.swift in Sources */,
+                                9A880C92584B44F1B4ABEA5E /* LoginViewModel.swift in Sources */,
+                                F17898942E1414AF000AEA35 /* TableBlockAttachment.swift in Sources */,
 				F17898952E1414AF000AEA35 /* TableBlockView.swift in Sources */,
 				F164B1042E3CD4F600D8DABA /* UserInfo.swift in Sources */,
 				F1DF3B252DF9B5CD00D8445A /* BorderedTextField.swift in Sources */,

--- a/chatGPT/Presentation/Coordinator/AppCoordinator.swift
+++ b/chatGPT/Presentation/Coordinator/AppCoordinator.swift
@@ -161,7 +161,8 @@ final class AppCoordinator {
     }
 
     private func showLogin() {
-        let vc = LoginViewController { [weak self] in
+        let vm = LoginViewModel()
+        let vc = LoginViewController(viewModel: vm) { [weak self] in
             guard let self = self else { return }
             if self.getKeyUseCase.execute() != nil {
                 self.showMain()

--- a/chatGPT/Presentation/Scene/Cells/ChatMessageCell.swift
+++ b/chatGPT/Presentation/Scene/Cells/ChatMessageCell.swift
@@ -303,7 +303,7 @@ final class ChatMessageCell: UITableViewCell {
     }
 
     // 셀 내용을 주어진 메시지로 구성
-    func configure(with message: ChatViewModel.ChatMessage,
+    func configure(with message: MainViewModel.ChatMessage,
                    parser: ParseMarkdownUseCase) {
         attachmentsStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
         userImageCollectionView.reloadData()

--- a/chatGPT/Presentation/Scene/ViewController/LoginViewController.swift
+++ b/chatGPT/Presentation/Scene/ViewController/LoginViewController.swift
@@ -2,18 +2,9 @@ import UIKit
 import SnapKit
 import RxSwift
 import RxCocoa
-import FirebaseAuth
-import GoogleSignIn
-import FirebaseCore
-
-enum LoginError: Error {
-    case missingClientID
-    case missingRootViewController
-    case missingToken
-    case firebaseAuthFailed
-}
 
 final class LoginViewController: UIViewController {
+    private let viewModel: LoginViewModel
     private let disposeBag = DisposeBag()
     private let completion: () -> Void
 
@@ -44,7 +35,8 @@ final class LoginViewController: UIViewController {
         return label
     }()
 
-    init(completion: @escaping () -> Void) {
+    init(viewModel: LoginViewModel, completion: @escaping () -> Void) {
+        self.viewModel = viewModel
         self.completion = completion
         super.init(nibName: nil, bundle: nil)
     }
@@ -82,65 +74,14 @@ final class LoginViewController: UIViewController {
     }
 
     private func bind() {
-        loginButton.rx.tap
-                .throttle(.milliseconds(500), scheduler: MainScheduler.instance)
-                .flatMapLatest { [weak self] _ -> Observable<AuthDataResult> in
-                    guard let self = self else { return .empty() }
-                    return self.signInWithGoogle()
-                        .catch { _ in
-                            return .empty() // ✅ 에러로 끊지 않고 스트림 유지
-                        }
-                }
-                .observe(on: MainScheduler.instance)
-                .subscribe(onNext: { [weak self] _ in
-                    self?.completion()
-                })
-                .disposed(by: disposeBag)
-    }
+        let input = LoginViewModel.Input(loginTap: loginButton.rx.tap.asObservable())
+        let output = viewModel.transform(input: input)
 
-    private func signInWithGoogle() -> Observable<AuthDataResult> {
-        return Observable.create { observer in
-            guard let clientID = FirebaseApp.app()?.options.clientID else {
-                observer.onError(LoginError.missingClientID)
-                return Disposables.create()
-            }
-
-            let scenes = UIApplication.shared.connectedScenes
-            guard let windowScene = scenes.first as? UIWindowScene,
-                  let rootVC = windowScene.windows.first(where: { $0.isKeyWindow })?.rootViewController else {
-                observer.onError(LoginError.missingRootViewController)
-                return Disposables.create()
-            }
-
-            let config = GIDConfiguration(clientID: clientID)
-            GIDSignIn.sharedInstance.configuration = config
-
-            
-            GIDSignIn.sharedInstance.signIn(withPresenting: rootVC) { result, error in
-                if let error = error {
-                    observer.onError(error)
-                    return
-                }
-
-                guard let idToken = result?.user.idToken?.tokenString,
-                      let accessToken = result?.user.accessToken.tokenString else {
-                    observer.onError(LoginError.missingToken)
-                    return
-                }
-
-                let credential = GoogleAuthProvider.credential(withIDToken: idToken, accessToken: accessToken)
-                Auth.auth().signIn(with: credential) { authResult, error in
-                    if let error = error {
-                        observer.onError(error)
-                    } else if let authResult = authResult {
-                        observer.onNext(authResult)
-                        observer.onCompleted()
-                    } else {
-                        observer.onError(LoginError.firebaseAuthFailed)
-                    }
-                }
-            }
-            return Disposables.create()
-        }
+        output.loginResult
+            .observe(on: MainScheduler.instance)
+            .bind(onNext: { [weak self] _ in
+                self?.completion()
+            })
+            .disposed(by: disposeBag)
     }
 }

--- a/chatGPT/Presentation/Scene/ViewModel/LoginViewModel.swift
+++ b/chatGPT/Presentation/Scene/ViewModel/LoginViewModel.swift
@@ -1,0 +1,79 @@
+import UIKit
+import RxSwift
+import RxCocoa
+import FirebaseAuth
+import GoogleSignIn
+import FirebaseCore
+
+final class LoginViewModel {
+    struct Input {
+        let loginTap: Observable<Void>
+    }
+
+    struct Output {
+        let loginResult: Observable<AuthDataResult>
+    }
+
+    func transform(input: Input) -> Output {
+        let result = input.loginTap
+            .throttle(.milliseconds(500), scheduler: MainScheduler.instance)
+            .flatMapLatest { [weak self] _ -> Observable<AuthDataResult> in
+                guard let self = self else { return .empty() }
+                return self.signInWithGoogle()
+                    .catch { _ in .empty() }
+            }
+        return Output(loginResult: result)
+    }
+
+    private func signInWithGoogle() -> Observable<AuthDataResult> {
+        return Observable.create { observer in
+            guard let clientID = FirebaseApp.app()?.options.clientID else {
+                observer.onError(LoginError.missingClientID)
+                return Disposables.create()
+            }
+
+            let scenes = UIApplication.shared.connectedScenes
+            guard let windowScene = scenes.first as? UIWindowScene,
+                  let rootVC = windowScene.windows.first(where: { $0.isKeyWindow })?.rootViewController else {
+                observer.onError(LoginError.missingRootViewController)
+                return Disposables.create()
+            }
+
+            let config = GIDConfiguration(clientID: clientID)
+            GIDSignIn.sharedInstance.configuration = config
+
+            GIDSignIn.sharedInstance.signIn(withPresenting: rootVC) { result, error in
+                if let error = error {
+                    observer.onError(error)
+                    return
+                }
+
+                guard let idToken = result?.user.idToken?.tokenString,
+                      let accessToken = result?.user.accessToken.tokenString else {
+                    observer.onError(LoginError.missingToken)
+                    return
+                }
+
+                let credential = GoogleAuthProvider.credential(withIDToken: idToken, accessToken: accessToken)
+                Auth.auth().signIn(with: credential) { authResult, error in
+                    if let error = error {
+                        observer.onError(error)
+                    } else if let authResult = authResult {
+                        observer.onNext(authResult)
+                        observer.onCompleted()
+                    } else {
+                        observer.onError(LoginError.firebaseAuthFailed)
+                    }
+                }
+            }
+            return Disposables.create()
+        }
+    }
+}
+
+enum LoginError: Error {
+    case missingClientID
+    case missingRootViewController
+    case missingToken
+    case firebaseAuthFailed
+}

--- a/chatGPT/Presentation/Scene/ViewModel/MainViewModel.swift
+++ b/chatGPT/Presentation/Scene/ViewModel/MainViewModel.swift
@@ -1,5 +1,5 @@
 //
-//  ChatViewModel.swift
+//  MainViewModel.swift
 //  chatGPT
 //
 //  Created by 홍정연 on 6/17/25.
@@ -10,7 +10,7 @@ import UIKit
 import RxSwift
 import RxRelay
 
-final class ChatViewModel {
+final class MainViewModel {
     enum MessageType {
         case user
         case assistant


### PR DESCRIPTION
## Summary
- move Google sign-in logic into new `LoginViewModel`
- rename `ChatViewModel` to `MainViewModel` and update usages
- wire view models through coordinator and project file

## Testing
- `swift test` *(fails: unable to clone RxSwift repository, CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68947c6fcf18832b9d38390f0e5e51f3