### PR TITLE
Add cancelable chat send

### DIFF
--- a/chatGPT/Data/OpenAIRepository.swift
+++ b/chatGPT/Data/OpenAIRepository.swift
@@ -10,9 +10,9 @@ import RxSwift
 
 protocol OpenAIRepository {
     func fetchAvailableModels(completion: @escaping (Result<[OpenAIModel], Error>) -> Void)
-    func sendChat(messages: [Message], model: OpenAIModel, stream: Bool, completion: @escaping (Result<String, Error>) -> Void)
+    func sendChat(messages: [Message], model: OpenAIModel, stream: Bool, completion: @escaping (Result<String, Error>) -> Void) -> CancelToken
     func sendChatStream(messages: [Message], model: OpenAIModel) -> Observable<String>
-    func sendVision(messages: [VisionMessage], model: OpenAIModel, stream: Bool, completion: @escaping (Result<String, Error>) -> Void)
+    func sendVision(messages: [VisionMessage], model: OpenAIModel, stream: Bool, completion: @escaping (Result<String, Error>) -> Void) -> CancelToken
     func sendVisionStream(messages: [VisionMessage], model: OpenAIModel) -> Observable<String>
 
     func generateImage(prompt: String, size: String, model: String, completion: @escaping (Result<[String], Error>) -> Void)

--- a/chatGPT/Data/OpenAIRepositoryImpl.swift
+++ b/chatGPT/Data/OpenAIRepositoryImpl.swift
@@ -16,8 +16,11 @@ final class OpenAIRepositoryImpl: OpenAIRepository {
     }
     
     /// 채팅전송
-    func sendChat(messages: [Message], model: OpenAIModel, stream: Bool, completion: @escaping (Result<String, Error>) -> Void) {
-        service.request(.chat(messages: messages, model: model, stream: stream)) { (result: Result<OpenAIResponse, Error>) in
+    func sendChat(messages: [Message],
+                  model: OpenAIModel,
+                  stream: Bool,
+                  completion: @escaping (Result<String, Error>) -> Void) -> CancelToken {
+        return service.request(.chat(messages: messages, model: model, stream: stream)) { (result: Result<OpenAIResponse, Error>) in
             switch result {
             case .success(let decoded):
                 let reply = decoded.choices.first?.message.content ?? ""
@@ -32,8 +35,11 @@ final class OpenAIRepositoryImpl: OpenAIRepository {
         service.requestStream(.chat(messages: messages, model: model, stream: true))
     }
 
-    func sendVision(messages: [VisionMessage], model: OpenAIModel, stream: Bool, completion: @escaping (Result<String, Error>) -> Void) {
-        service.request(.vision(messages: messages, model: model, stream: stream)) { (result: Result<OpenAIResponse, Error>) in
+    func sendVision(messages: [VisionMessage],
+                    model: OpenAIModel,
+                    stream: Bool,
+                    completion: @escaping (Result<String, Error>) -> Void) -> CancelToken {
+        return service.request(.vision(messages: messages, model: model, stream: stream)) { (result: Result<OpenAIResponse, Error>) in
             switch result {
             case .success(let decoded):
                 let reply = decoded.choices.first?.message.content ?? ""

--- a/chatGPT/Data/OpenAITranslationRepository.swift
+++ b/chatGPT/Data/OpenAITranslationRepository.swift
@@ -14,7 +14,7 @@ final class OpenAITranslationRepository: TranslationRepository {
         Single.create { single in
             let system = Message(role: .system, content: "Translate the following text to English. Respond only with the translated text.")
             let user = Message(role: .user, content: text)
-            self.repository.sendChat(messages: [system, user], model: self.model, stream: false) { result in
+            let token = self.repository.sendChat(messages: [system, user], model: self.model, stream: false) { result in
                 switch result {
                 case .success(let translated):
                     single(.success(translated.trimmingCharacters(in: .whitespacesAndNewlines)))
@@ -22,7 +22,7 @@ final class OpenAITranslationRepository: TranslationRepository {
                     single(.failure(error))
                 }
             }
-            return Disposables.create()
+            return Disposables.create { token.cancel() }
         }
     }
 }

--- a/chatGPT/Domain/UseCase/SendChatMessageUseCase.swift
+++ b/chatGPT/Domain/UseCase/SendChatMessageUseCase.swift
@@ -15,6 +15,6 @@ final class SendChatMessageUseCase {
     }
 
     func execute(messages: [Message], model: OpenAIModel, stream: Bool, completion: @escaping (Result<String, Error>) -> Void) {
-        repository.sendChat(messages: messages, model: model, stream: stream, completion: completion)
+        _ = repository.sendChat(messages: messages, model: model, stream: stream, completion: completion)
     }
 }

--- a/chatGPT/Domain/UseCase/SummarizeMessagesUseCase.swift
+++ b/chatGPT/Domain/UseCase/SummarizeMessagesUseCase.swift
@@ -20,7 +20,7 @@ final class SummarizeMessagesUseCase {
         let text = messages.map { "\($0.role.rawValue): \($0.content)" }.joined(separator: "\n")
         let prompt = "다음 대화를 15자 내외로 간결하고 직관적인 제목으로 요약해 줘.\n" + text
         let reqMessages = [Message(role: .system, content: prompt)]
-        repository.sendChat(messages: reqMessages, model: model, stream: false) { [weak self] result in
+        _ = repository.sendChat(messages: reqMessages, model: model, stream: false) { [weak self] result in
             switch result {
             case .success(let summary):
                 completion(.success(summary))

--- a/chatGPT/Presentation/Scene/ViewController/MainViewController.swift
+++ b/chatGPT/Presentation/Scene/ViewController/MainViewController.swift
@@ -248,6 +248,9 @@ final class MainViewController: UIViewController {
                                     model: self.selectedModel,
                                     stream: self.streamEnabled)
         }
+        self.composerView.onStopButtonTapped = { [weak self] in
+            self?.viewModel.cancelCurrent()
+        }
         self.composerView.onPlusButtonTapped = { [weak self] in
             self?.handleAlbumOption()
         }
@@ -280,6 +283,14 @@ final class MainViewController: UIViewController {
                         }
                     }
                 }
+            })
+           .disposed(by: disposeBag)
+
+        viewModel.isProcessing
+            .distinctUntilChanged()
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] loading in
+                self?.composerView.isSending = loading
             })
             .disposed(by: disposeBag)
         

--- a/chatGPT/Service/OpenAIServiceProtocol.swift
+++ b/chatGPT/Service/OpenAIServiceProtocol.swift
@@ -2,7 +2,8 @@ import Foundation
 import RxSwift
 
 protocol OpenAIServiceProtocol {
-    func request<T: Decodable>(_ endpoint: OpenAIEndpoint, completion: @escaping (Result<T, Error>) -> Void)
+    @discardableResult
+    func request<T: Decodable>(_ endpoint: OpenAIEndpoint, completion: @escaping (Result<T, Error>) -> Void) -> CancelToken
     func requestStream(_ endpoint: OpenAIEndpoint) -> Observable<String>
     func upload<T: Decodable>(_ endpoint: OpenAIEndpoint, completion: @escaping (Result<T, Error>) -> Void)
 }

--- a/chatGPTTests/AnalyzeUserInputUseCaseTests.swift
+++ b/chatGPTTests/AnalyzeUserInputUseCaseTests.swift
@@ -15,9 +15,9 @@ final class StubInfoRepository: UserInfoRepository {
 final class StubOpenAIRepository: OpenAIRepository {
     var analysisResult: PreferenceAnalysisResult = .init(info: UserInfo(attributes: [:]))
     func fetchAvailableModels(completion: @escaping (Result<[OpenAIModel], Error>) -> Void) {}
-    func sendChat(messages: [Message], model: OpenAIModel, stream: Bool, completion: @escaping (Result<String, Error>) -> Void) {}
+    func sendChat(messages: [Message], model: OpenAIModel, stream: Bool, completion: @escaping (Result<String, Error>) -> Void) -> CancelToken { CancelToken { } }
     func sendChatStream(messages: [Message], model: OpenAIModel) -> Observable<String> { .empty() }
-    func sendVision(messages: [VisionMessage], model: OpenAIModel, stream: Bool, completion: @escaping (Result<String, Error>) -> Void) {}
+    func sendVision(messages: [VisionMessage], model: OpenAIModel, stream: Bool, completion: @escaping (Result<String, Error>) -> Void) -> CancelToken { CancelToken { } }
     func sendVisionStream(messages: [VisionMessage], model: OpenAIModel) -> Observable<String> { .empty() }
     func generateImage(prompt: String, size: String, model: String, completion: @escaping (Result<[String], Error>) -> Void) {}
     func detectImageIntent(prompt: String) -> Single<Bool> { .just(false) }

--- a/chatGPTTests/DetectImageRequestUseCaseTests.swift
+++ b/chatGPTTests/DetectImageRequestUseCaseTests.swift
@@ -12,9 +12,9 @@ final class StubOpenAIRepository: OpenAIRepository {
     }
 
     func fetchAvailableModels(completion: @escaping (Result<[OpenAIModel], Error>) -> Void) {}
-    func sendChat(messages: [Message], model: OpenAIModel, stream: Bool, completion: @escaping (Result<String, Error>) -> Void) {}
+    func sendChat(messages: [Message], model: OpenAIModel, stream: Bool, completion: @escaping (Result<String, Error>) -> Void) -> CancelToken { CancelToken { } }
     func sendChatStream(messages: [Message], model: OpenAIModel) -> Observable<String> { .empty() }
-    func sendVision(messages: [VisionMessage], model: OpenAIModel, stream: Bool, completion: @escaping (Result<String, Error>) -> Void) {}
+    func sendVision(messages: [VisionMessage], model: OpenAIModel, stream: Bool, completion: @escaping (Result<String, Error>) -> Void) -> CancelToken { CancelToken { } }
     func sendVisionStream(messages: [VisionMessage], model: OpenAIModel) -> Observable<String> { .empty() }
     func generateImage(prompt: String, size: String, model: String, completion: @escaping (Result<[String], Error>) -> Void) {}
 }


### PR DESCRIPTION
## Summary
- swap send button to pause while sending and support cancellation
- finalize partial streaming replies and persist when stopped
- add CancelToken to handle request aborts

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/ReactiveX/RxSwift.git: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6895ae97c45c832b805a039820213d0c